### PR TITLE
add support for MAC and split/fix tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ build:
     pull: true
     commands:
       - go get -u github.com/stretchr/testify/assert
-      - go get -u github.com/nu7hatch/gouuid
+      - go get -u github.com/pborman/uuid
       - go get -u github.com/asaskevich/govalidator
       - go get -u github.com/go-openapi/errors
       - go test -race

--- a/default.go
+++ b/default.go
@@ -96,6 +96,9 @@ func init() {
 	ip6 := IPv6("")
 	Default.Add("ipv6", &ip6, govalidator.IsIPv6)
 
+	mac := MAC("")
+	Default.Add("mac", &mac, govalidator.IsMAC)
+
 	uid := UUID("")
 	Default.Add("uuid", &uid, govalidator.IsUUID)
 
@@ -383,6 +386,45 @@ func (u IPv6) Value() (driver.Value, error) {
 }
 
 func (u IPv6) String() string {
+	return string(u)
+}
+
+// MAC represents a 48 bit MAC address
+//
+// swagger:strfmt mac
+type MAC string
+
+// MarshalText turns this instance into text
+func (u MAC) MarshalText() ([]byte, error) {
+	return []byte(string(u)), nil
+}
+
+// UnmarshalText hydrates this instance from text
+func (u *MAC) UnmarshalText(data []byte) error { // validation is performed later on
+	*u = MAC(string(data))
+	return nil
+}
+
+// Scan read a value from a database driver
+func (u *MAC) Scan(raw interface{}) error {
+	switch v := raw.(type) {
+	case []byte:
+		*u = MAC(string(v))
+	case string:
+		*u = MAC(v)
+	default:
+		return fmt.Errorf("cannot sql.Scan() strfmt.IPv4 from: %#v", v)
+	}
+
+	return nil
+}
+
+// Value converts a value to a database driver value
+func (u MAC) Value() (driver.Value, error) {
+	return driver.Value(string(u)), nil
+}
+
+func (u MAC) String() string {
 	return string(u)
 }
 

--- a/default_test.go
+++ b/default_test.go
@@ -17,11 +17,25 @@ package strfmt
 import (
 	"testing"
 
-	"github.com/nu7hatch/gouuid"
+	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFormats(t *testing.T) {
+func testValid(t *testing.T, name, value string) {
+	ok := Default.Validates(name, value)
+	if !ok {
+		t.Errorf("expected %s of type %s to be valid", value, name)
+	}
+}
+
+func testInvalid(t *testing.T, name, value string) {
+	ok := Default.Validates(name, value)
+	if ok {
+		t.Errorf("expected %s of type %s to be invalid", value, name)
+	}
+}
+
+func TestFormatURI(t *testing.T) {
 	uri := URI("http://somewhere.com")
 	str := string("http://somewhereelse.com")
 	b := []byte(str)
@@ -33,10 +47,15 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("http://somewhereelse.com"), b)
 
+	testValid(t, "uri", str)
+	testInvalid(t, "uri", "somewhere.com")
+}
+
+func TestFormatEmail(t *testing.T) {
 	email := Email("somebody@somewhere.com")
-	str = string("somebodyelse@somewhere.com")
-	b = []byte(str)
-	err = email.UnmarshalText(b)
+	str := string("somebodyelse@somewhere.com")
+	b := []byte(str)
+	err := email.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, Email("somebodyelse@somewhere.com"), string(b))
 
@@ -44,10 +63,15 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("somebodyelse@somewhere.com"), b)
 
+	testValid(t, "email", str)
+	testInvalid(t, "email", "somebody@somewhere@com")
+}
+
+func TestFormatHostname(t *testing.T) {
 	hostname := Hostname("somewhere.com")
-	str = string("somewhere.com")
-	b = []byte(str)
-	err = hostname.UnmarshalText(b)
+	str := string("somewhere.com")
+	b := []byte(str)
+	err := hostname.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, Hostname("somewhere.com"), string(b))
 
@@ -55,10 +79,15 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("somewhere.com"), b)
 
+	testValid(t, "hostname", str)
+	testInvalid(t, "hostname", "somewhere.com!")
+}
+
+func TestFormatIPv4(t *testing.T) {
 	ipv4 := IPv4("192.168.254.1")
-	str = string("192.168.254.2")
-	b = []byte(str)
-	err = ipv4.UnmarshalText(b)
+	str := string("192.168.254.2")
+	b := []byte(str)
+	err := ipv4.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, IPv4("192.168.254.2"), string(b))
 
@@ -66,10 +95,15 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("192.168.254.2"), b)
 
+	testValid(t, "ipv4", str)
+	testInvalid(t, "ipv4", "192.168.254.2.2")
+}
+
+func TestFormatIPv6(t *testing.T) {
 	ipv6 := IPv6("::1")
-	str = string("::2")
-	b = []byte(str)
-	err = ipv6.UnmarshalText(b)
+	str := string("::2")
+	b := []byte(str)
+	err := ipv6.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, IPv6("::2"), string(b))
 
@@ -77,12 +111,33 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("::2"), b)
 
-	first3, _ := uuid.NewV3(uuid.NamespaceURL, []byte("somewhere.com"))
-	other3, _ := uuid.NewV3(uuid.NamespaceURL, []byte("somewhereelse.com"))
+	testValid(t, "ipv6", str)
+	testInvalid(t, "ipv6", "127.0.0.1")
+}
+
+func TestFormatMAC(t *testing.T) {
+	mac := MAC("01:02:03:04:05:06")
+	str := string("06:05:04:03:02:01")
+	b := []byte(str)
+	err := mac.UnmarshalText(b)
+	assert.NoError(t, err)
+	assert.EqualValues(t, MAC("06:05:04:03:02:01"), string(b))
+
+	b, err = mac.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("06:05:04:03:02:01"), b)
+
+	testValid(t, "mac", str)
+	testInvalid(t, "mac", "01:02:03:04:05")
+}
+
+func TestFormatUUID3(t *testing.T) {
+	first3 := uuid.NewMD5(uuid.NameSpace_URL, []byte("somewhere.com"))
+	other3 := uuid.NewMD5(uuid.NameSpace_URL, []byte("somewhereelse.com"))
 	uuid3 := UUID3(first3.String())
-	str = string(other3.String())
-	b = []byte(str)
-	err = uuid3.UnmarshalText(b)
+	str := string(other3.String())
+	b := []byte(str)
+	err := uuid3.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, UUID3(other3.String()), string(b))
 
@@ -90,12 +145,17 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, []byte(other3.String()), b)
 
-	first4, _ := uuid.NewV4()
-	other4, _ := uuid.NewV4()
+	testValid(t, "uuid3", str)
+	testInvalid(t, "uuid3", "not-a-uuid")
+}
+
+func TestFormatUUID4(t *testing.T) {
+	first4 := uuid.NewRandom()
+	other4 := uuid.NewRandom()
 	uuid4 := UUID4(first4.String())
-	str = string(other4.String())
-	b = []byte(str)
-	err = uuid4.UnmarshalText(b)
+	str := string(other4.String())
+	b := []byte(str)
+	err := uuid4.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, UUID4(other4.String()), string(b))
 
@@ -103,12 +163,17 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte(other4.String()), b)
 
-	first5, _ := uuid.NewV5(uuid.NamespaceURL, []byte("somewhere.com"))
-	other5, _ := uuid.NewV5(uuid.NamespaceURL, []byte("somewhereelse.com"))
+	testValid(t, "uuid4", str)
+	testInvalid(t, "uuid4", "not-a-uuid")
+}
+
+func TestFormatUUID5(t *testing.T) {
+	first5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhere.com"))
+	other5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhereelse.com"))
 	uuid5 := UUID5(first5.String())
-	str = string(other5.String())
-	b = []byte(str)
-	err = uuid5.UnmarshalText(b)
+	str := string(other5.String())
+	b := []byte(str)
+	err := uuid5.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, UUID5(other5.String()), string(b))
 
@@ -116,10 +181,17 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte(other5.String()), b)
 
+	testValid(t, "uuid5", str)
+	testInvalid(t, "uuid5", "not-a-uuid")
+}
+
+func TestFormatUUID(t *testing.T) {
+	first5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhere.com"))
+	other5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhereelse.com"))
 	uuid := UUID(first5.String())
-	str = string(other5.String())
-	b = []byte(str)
-	err = uuid.UnmarshalText(b)
+	str := string(other5.String())
+	b := []byte(str)
+	err := uuid.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, UUID(other5.String()), string(b))
 
@@ -127,43 +199,63 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte(other5.String()), b)
 
-	isbn := ISBN("0836217462")
-	str = string("0836217463")
-	b = []byte(str)
-	err = isbn.UnmarshalText(b)
+	testValid(t, "uuid", str)
+	testInvalid(t, "uuid", "not-a-uuid")
+}
+
+func TestFormatISBN(t *testing.T) {
+	isbn := ISBN("0321751043")
+	str := string("0321751043")
+	b := []byte(str)
+	err := isbn.UnmarshalText(b)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ISBN("0836217463"), string(b))
+	assert.EqualValues(t, ISBN("0321751043"), string(b))
 
 	b, err = isbn.MarshalText()
 	assert.NoError(t, err)
-	assert.Equal(t, []byte("0836217463"), b)
+	assert.Equal(t, []byte("0321751043"), b)
 
-	isbn10 := ISBN10("0836217462")
-	str = string("0836217463")
-	b = []byte(str)
-	err = isbn10.UnmarshalText(b)
+	testValid(t, "isbn", str)
+	testInvalid(t, "isbn", "836217463") // bad checksum
+}
+
+func TestFormatISBN10(t *testing.T) {
+	isbn10 := ISBN10("0321751043")
+	str := string("0321751043")
+	b := []byte(str)
+	err := isbn10.UnmarshalText(b)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ISBN10("0836217463"), string(b))
+	assert.EqualValues(t, ISBN10("0321751043"), string(b))
 
 	b, err = isbn10.MarshalText()
 	assert.NoError(t, err)
-	assert.Equal(t, []byte("0836217463"), b)
+	assert.Equal(t, []byte("0321751043"), b)
 
-	isbn13 := ISBN13("0836217462384")
-	str = string("0836217462385")
-	b = []byte(str)
-	err = isbn13.UnmarshalText(b)
+	testValid(t, "isbn10", str)
+	testInvalid(t, "isbn10", "836217463") // bad checksum
+}
+
+func TestFormatISBN13(t *testing.T) {
+	isbn13 := ISBN13("978-0321751041")
+	str := string("978-0321751041")
+	b := []byte(str)
+	err := isbn13.UnmarshalText(b)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ISBN13("0836217462385"), string(b))
+	assert.EqualValues(t, ISBN13("978-0321751041"), string(b))
 
 	b, err = isbn13.MarshalText()
 	assert.NoError(t, err)
-	assert.Equal(t, []byte("0836217462385"), b)
+	assert.Equal(t, []byte("978-0321751041"), b)
 
+	testValid(t, "isbn13", str)
+	testInvalid(t, "isbn13", "978-0321751042") // bad checksum
+}
+
+func TestFormatHexColor(t *testing.T) {
 	hexColor := HexColor("#FFFFFF")
-	str = string("#000000")
-	b = []byte(str)
-	err = hexColor.UnmarshalText(b)
+	str := string("#000000")
+	b := []byte(str)
+	err := hexColor.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, HexColor("#000000"), string(b))
 
@@ -171,10 +263,15 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("#000000"), b)
 
+	testValid(t, "hexcolor", str)
+	testInvalid(t, "hexcolor", "#fffffffz")
+}
+
+func TestFormatRGBColor(t *testing.T) {
 	rgbColor := RGBColor("rgb(255,255,255)")
-	str = string("rgb(0,0,0)")
-	b = []byte(str)
-	err = rgbColor.UnmarshalText(b)
+	str := string("rgb(0,0,0)")
+	b := []byte(str)
+	err := rgbColor.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, RGBColor("rgb(0,0,0)"), string(b))
 
@@ -182,10 +279,15 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("rgb(0,0,0)"), b)
 
+	testValid(t, "rgbcolor", str)
+	testInvalid(t, "rgbcolor", "rgb(300,0,0)")
+}
+
+func TestFormatSSN(t *testing.T) {
 	ssn := SSN("111-11-1111")
-	str = string("999 99 9999")
-	b = []byte(str)
-	err = ssn.UnmarshalText(b)
+	str := string("999 99 9999")
+	b := []byte(str)
+	err := ssn.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, SSN("999 99 9999"), string(b))
 
@@ -193,25 +295,54 @@ func TestFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("999 99 9999"), b)
 
-	creditCard := CreditCard("1111-1111-1111-1111")
-	str = string("9999-9999-9999-9999")
-	b = []byte(str)
-	err = creditCard.UnmarshalText(b)
+	testValid(t, "ssn", str)
+	testInvalid(t, "ssn", "999 99 999")
+}
+
+func TestFormatCreditCard(t *testing.T) {
+	creditCard := CreditCard("4111-1111-1111-1111")
+	str := string("4012-8888-8888-1881")
+	b := []byte(str)
+	err := creditCard.UnmarshalText(b)
 	assert.NoError(t, err)
-	assert.EqualValues(t, CreditCard("9999-9999-9999-9999"), string(b))
+	assert.EqualValues(t, CreditCard("4012-8888-8888-1881"), string(b))
 
 	b, err = creditCard.MarshalText()
 	assert.NoError(t, err)
-	assert.Equal(t, []byte("9999-9999-9999-9999"), b)
+	assert.Equal(t, []byte("4012-8888-8888-1881"), b)
 
+	testValid(t, "creditcard", str)
+	testInvalid(t, "creditcard", "9999-9999-9999-999") // bad checksum
+}
+
+func TestFormatPassword(t *testing.T) {
 	password := Password("super secret stuff here")
-	str = string("even more secret")
-	b = []byte(str)
-	err = password.UnmarshalText(b)
+	str := string("even more secret")
+	b := []byte(str)
+	err := password.UnmarshalText(b)
 	assert.NoError(t, err)
 	assert.EqualValues(t, Password("even more secret"), string(b))
 
 	b, err = password.MarshalText()
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("even more secret"), b)
+
+	// everything is valid
+	testValid(t, "password", str)
+}
+
+func TestFormatBase64(t *testing.T) {
+	b64 := Base64("ZWxpemFiZXRocG9zZXk=")
+	str := string("ZWxpemFiZXRocG9zZXk=")
+	b := []byte(str)
+	err := b64.UnmarshalText(b)
+	assert.NoError(t, err)
+	assert.EqualValues(t, Base64("ZWxpemFiZXRocG9zZXk="), string(b))
+
+	b, err = b64.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("ZWxpemFiZXRocG9zZXk="), b)
+
+	testValid(t, "byte", str)
+	testInvalid(t, "byte", "ZWxpemFiZXRocG9zZXk") // missing pad char
 }


### PR DESCRIPTION
Added support for a MAC address type as well as splitting up the
unit tests.  Added validation tests, which indicated some errors
in the unit tests data (e.g. uuid4/5 test data had no version
number in the uuid, and the isbns were bad).

Signed-off-by: Todd Neal <todd@tneal.org>