### PR TITLE
fix grammar mistake found by @PaulCapestany

### DIFF
--- a/time.go
+++ b/time.go
@@ -81,7 +81,8 @@ func ParseDateTime(data string) (DateTime, error) {
 
 // DateTime is a time but it serializes to ISO8601 format with millis
 // It knows how to read 3 different variations of a RFC3339 date time.
-// Most API's we encounter want either millisecond or second precision times. This just tries to make it worry-free.
+// Most APIs we encounter want either millisecond or second precision times.
+// This just tries to make it worry-free.
 //
 // swagger:strfmt date-time
 type DateTime time.Time


### PR DESCRIPTION
The grammar mistake fixed in this PR was found (and by accident fixed as vendor code) by @PaulCapestany.