### PR TITLE
Feat mgo compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 - go get -u github.com/mailru/easyjson
 - go get -u github.com/go-openapi/errors
 - go get -u github.com/mitchellh/mapstructure
+- go get -u gopkg.in/mgo.v2/bson
 script:
 - ./hack/coverage
 after_success:

--- a/bson.go
+++ b/bson.go
@@ -1,0 +1,124 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strfmt
+
+import (
+	"database/sql/driver"
+	"errors"
+	"fmt"
+
+	"github.com/mailru/easyjson/jlexer"
+	"github.com/mailru/easyjson/jwriter"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+func init() {
+	var id ObjectId
+	Default.Add("bsonobjectid", &id, IsBSONObjectID)
+}
+
+// IsBSONObjectID returns true when the string is a valid BSON.ObjectId
+func IsBSONObjectID(str string) bool {
+	var id bson.ObjectId
+	return id.UnmarshalText([]byte(str)) == nil
+}
+
+type ObjectId bson.ObjectId
+
+// NewObjectId creates a ObjectId from a Hex String
+func NewObjectId(hex string) ObjectId {
+	return ObjectId(bson.ObjectIdHex(hex))
+}
+
+// MarshalText turns this instance into text
+func (id *ObjectId) MarshalText() ([]byte, error) {
+	return []byte(bson.ObjectId(*id).Hex()), nil
+}
+
+// UnmarshalText hydrates this instance from text
+func (id *ObjectId) UnmarshalText(data []byte) error { // validation is performed later on
+	var rawID bson.ObjectId
+	if err := rawID.UnmarshalText(data); err != nil {
+		return err
+	}
+
+	*id = ObjectId(rawID)
+	return nil
+}
+
+// Scan read a value from a database driver
+func (id *ObjectId) Scan(raw interface{}) error {
+	var data []byte
+	switch v := raw.(type) {
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return fmt.Errorf("cannot sql.Scan() strfmt.URI from: %#v", v)
+	}
+
+	return id.UnmarshalText(data)
+}
+
+// Value converts a value to a database driver value
+func (id *ObjectId) Value() (driver.Value, error) {
+	return driver.Value(string(*id)), nil
+}
+
+func (id *ObjectId) String() string {
+	return string(*id)
+}
+
+func (id *ObjectId) MarshalJSON() ([]byte, error) {
+	var w jwriter.Writer
+	id.MarshalEasyJSON(&w)
+	return w.BuildBytes()
+}
+
+func (id *ObjectId) MarshalEasyJSON(w *jwriter.Writer) {
+	w.String(bson.ObjectId(*id).Hex())
+}
+
+func (id *ObjectId) UnmarshalJSON(data []byte) error {
+	l := jlexer.Lexer{Data: data}
+	id.UnmarshalEasyJSON(&l)
+	return l.Error()
+}
+
+func (id *ObjectId) UnmarshalEasyJSON(in *jlexer.Lexer) {
+	if data := in.String(); in.Ok() {
+		*id = NewObjectId(data)
+	}
+}
+
+func (id *ObjectId) GetBSON() (interface{}, error) {
+	return bson.M{"data": bson.ObjectId(*id).Hex()}, nil
+}
+
+func (id *ObjectId) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*id = NewObjectId(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as ObjectId")
+}

--- a/bson_test.go
+++ b/bson_test.go
@@ -1,0 +1,53 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strfmt
+
+import (
+	"testing"
+
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBSONObjectId_fullCycle(t *testing.T) {
+	id := NewObjectId("507f1f77bcf86cd799439011")
+	bytes, err := id.MarshalText()
+	assert.NoError(t, err)
+
+	var idCopy ObjectId
+
+	err = idCopy.Scan(bytes)
+	assert.NoError(t, err)
+	assert.Equal(t, id, idCopy)
+
+	err = idCopy.UnmarshalText(bytes)
+	assert.NoError(t, err)
+	assert.Equal(t, id, idCopy)
+
+	jsonBytes, err := id.MarshalJSON()
+	assert.NoError(t, err)
+
+	err = idCopy.UnmarshalJSON(jsonBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, id, idCopy)
+
+	bsonBytes, err := bson.Marshal(&id)
+	assert.NoError(t, err)
+
+	err = bson.Unmarshal(bsonBytes, &idCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, id, idCopy)
+}

--- a/date.go
+++ b/date.go
@@ -16,9 +16,12 @@ package strfmt
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
+
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
@@ -127,4 +130,23 @@ func (t *Date) UnmarshalEasyJSON(in *jlexer.Lexer) {
 		}
 		*t = Date(tt)
 	}
+}
+
+func (t *Date) GetBSON() (interface{}, error) {
+	return bson.M{"data": t.String()}, nil
+}
+
+func (t *Date) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		rd, err := time.Parse(RFC3339FullDate, data)
+		*t = Date(rd)
+		return err
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as Duration")
 }

--- a/date_test.go
+++ b/date_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/mgo.v2/bson"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,6 +50,16 @@ func TestDate(t *testing.T) {
 	b, err = pp.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	dateOriginal := Date(time.Date(2014, 10, 10, 0, 0, 0, 0, time.UTC))
+
+	bsonData, err := bson.Marshal(&dateOriginal)
+	assert.NoError(t, err)
+
+	var dateCopy Date
+	err = bson.Unmarshal(bsonData, &dateCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, dateOriginal, dateCopy)
 }
 
 func TestDate_Scan(t *testing.T) {

--- a/default.go
+++ b/default.go
@@ -17,6 +17,7 @@ package strfmt
 import (
 	"database/sql/driver"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -24,6 +25,8 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
+
+	"gopkg.in/mgo.v2/bson"
 )
 
 const (
@@ -252,6 +255,24 @@ func (b *Base64) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	}
 }
 
+func (b *Base64) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*b)}, nil
+}
+
+func (b *Base64) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*b = Base64(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as Base64")
+}
+
 // URI represents the uri string format as specified by the json schema spec
 //
 // swagger:strfmt uri
@@ -311,6 +332,24 @@ func (u *URI) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	if data := in.String(); in.Ok() {
 		*u = URI(data)
 	}
+}
+
+func (u *URI) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *URI) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = URI(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as URI")
 }
 
 // Email represents the email string format as specified by the json schema spec
@@ -374,6 +413,24 @@ func (e *Email) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	}
 }
 
+func (e *Email) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*e)}, nil
+}
+
+func (e *Email) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*e = Email(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as Email")
+}
+
 // Hostname represents the hostname string format as specified by the json schema spec
 //
 // swagger:strfmt hostname
@@ -433,6 +490,24 @@ func (h *Hostname) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	if data := in.String(); in.Ok() {
 		*h = Hostname(data)
 	}
+}
+
+func (h *Hostname) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*h)}, nil
+}
+
+func (h *Hostname) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*h = Hostname(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as Hostname")
 }
 
 // IPv4 represents an IP v4 address
@@ -496,6 +571,24 @@ func (u *IPv4) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	}
 }
 
+func (u *IPv4) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *IPv4) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = IPv4(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as IPv4")
+}
+
 // IPv6 represents an IP v6 address
 //
 // swagger:strfmt ipv6
@@ -555,6 +648,24 @@ func (u *IPv6) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	if data := in.String(); in.Ok() {
 		*u = IPv6(data)
 	}
+}
+
+func (u *IPv6) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *IPv6) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = IPv6(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as IPv6")
 }
 
 // MAC represents a 48 bit MAC address
@@ -618,6 +729,24 @@ func (u *MAC) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	}
 }
 
+func (u *MAC) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *MAC) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = MAC(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as MAC")
+}
+
 // UUID represents a uuid string format
 //
 // swagger:strfmt uuid
@@ -677,6 +806,24 @@ func (u *UUID) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	if data := in.String(); in.Ok() {
 		*u = UUID(data)
 	}
+}
+
+func (u *UUID) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *UUID) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = UUID(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as UUID")
 }
 
 // UUID3 represents a uuid3 string format
@@ -740,6 +887,24 @@ func (u *UUID3) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	}
 }
 
+func (u *UUID3) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *UUID3) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = UUID3(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as UUID3")
+}
+
 // UUID4 represents a uuid4 string format
 //
 // swagger:strfmt uuid4
@@ -799,6 +964,24 @@ func (u *UUID4) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	if data := in.String(); in.Ok() {
 		*u = UUID4(data)
 	}
+}
+
+func (u *UUID4) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *UUID4) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = UUID4(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as UUID4")
 }
 
 // UUID5 represents a uuid5 string format
@@ -862,6 +1045,24 @@ func (u *UUID5) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	}
 }
 
+func (u *UUID5) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *UUID5) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = UUID5(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as UUID5")
+}
+
 // ISBN represents an isbn string format
 //
 // swagger:strfmt isbn
@@ -921,6 +1122,24 @@ func (u *ISBN) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	if data := in.String(); in.Ok() {
 		*u = ISBN(data)
 	}
+}
+
+func (u *ISBN) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *ISBN) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = ISBN(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as ISBN")
 }
 
 // ISBN10 represents an isbn 10 string format
@@ -984,6 +1203,24 @@ func (u *ISBN10) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	}
 }
 
+func (u *ISBN10) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *ISBN10) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = ISBN10(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as ISBN10")
+}
+
 // ISBN13 represents an isbn 13 string format
 //
 // swagger:strfmt isbn13
@@ -1043,6 +1280,24 @@ func (u *ISBN13) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	if data := in.String(); in.Ok() {
 		*u = ISBN13(data)
 	}
+}
+
+func (u *ISBN13) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *ISBN13) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = ISBN13(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as ISBN13")
 }
 
 // CreditCard represents a credit card string format
@@ -1106,6 +1361,24 @@ func (u *CreditCard) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	}
 }
 
+func (u *CreditCard) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *CreditCard) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = CreditCard(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as CreditCard")
+}
+
 // SSN represents a social security string format
 //
 // swagger:strfmt ssn
@@ -1165,6 +1438,24 @@ func (u *SSN) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	if data := in.String(); in.Ok() {
 		*u = SSN(data)
 	}
+}
+
+func (u *SSN) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*u)}, nil
+}
+
+func (u *SSN) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*u = SSN(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as SSN")
 }
 
 // HexColor represents a hex color string format
@@ -1228,6 +1519,24 @@ func (h *HexColor) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	}
 }
 
+func (h *HexColor) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*h)}, nil
+}
+
+func (h *HexColor) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*h = HexColor(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as HexColor")
+}
+
 // RGBColor represents a RGB color string format
 //
 // swagger:strfmt rgbcolor
@@ -1287,6 +1596,24 @@ func (r *RGBColor) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	if data := in.String(); in.Ok() {
 		*r = RGBColor(data)
 	}
+}
+
+func (r *RGBColor) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*r)}, nil
+}
+
+func (r *RGBColor) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*r = RGBColor(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as RGBColor")
 }
 
 // Password represents a password.
@@ -1349,4 +1676,22 @@ func (r *Password) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	if data := in.String(); in.Ok() {
 		*r = Password(data)
 	}
+}
+
+func (r *Password) GetBSON() (interface{}, error) {
+	return bson.M{"data": string(*r)}, nil
+}
+
+func (r *Password) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(string); ok {
+		*r = Password(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as Password")
 }

--- a/default_test.go
+++ b/default_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/mgo.v2/bson"
 )
 
 func testValid(t *testing.T, name, value string) {
@@ -57,6 +58,14 @@ func TestFormatURI(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
 
+	bsonData, err := bson.Marshal(&uri)
+	assert.NoError(t, err)
+
+	var uriCopy URI
+	err = bson.Unmarshal(bsonData, &uriCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, uri, uriCopy)
+
 	testValid(t, "uri", str)
 	testInvalid(t, "uri", "somewhere.com")
 }
@@ -82,6 +91,14 @@ func TestFormatEmail(t *testing.T) {
 	b, err = email.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	bsonData, err := bson.Marshal(&email)
+	assert.NoError(t, err)
+
+	var emailCopy Email
+	err = bson.Unmarshal(bsonData, &emailCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, email, emailCopy)
 
 	testValid(t, "email", str)
 	testInvalid(t, "email", "somebody@somewhere@com")
@@ -109,6 +126,14 @@ func TestFormatHostname(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
 
+	bsonData, err := bson.Marshal(&hostname)
+	assert.NoError(t, err)
+
+	var hostnameCopy Hostname
+	err = bson.Unmarshal(bsonData, &hostnameCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, hostname, hostnameCopy)
+
 	testValid(t, "hostname", str)
 	testInvalid(t, "hostname", "somewhere.com!")
 }
@@ -134,6 +159,14 @@ func TestFormatIPv4(t *testing.T) {
 	b, err = ipv4.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	bsonData, err := bson.Marshal(&ipv4)
+	assert.NoError(t, err)
+
+	var ipv4Copy IPv4
+	err = bson.Unmarshal(bsonData, &ipv4Copy)
+	assert.NoError(t, err)
+	assert.Equal(t, ipv4, ipv4Copy)
 
 	testValid(t, "ipv4", str)
 	testInvalid(t, "ipv4", "192.168.254.2.2")
@@ -161,6 +194,14 @@ func TestFormatIPv6(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
 
+	bsonData, err := bson.Marshal(&ipv6)
+	assert.NoError(t, err)
+
+	var ipv6Copy IPv6
+	err = bson.Unmarshal(bsonData, &ipv6Copy)
+	assert.NoError(t, err)
+	assert.Equal(t, ipv6, ipv6Copy)
+
 	testValid(t, "ipv6", str)
 	testInvalid(t, "ipv6", "127.0.0.1")
 }
@@ -186,6 +227,14 @@ func TestFormatMAC(t *testing.T) {
 	b, err = mac.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	bsonData, err := bson.Marshal(&mac)
+	assert.NoError(t, err)
+
+	var macCopy MAC
+	err = bson.Unmarshal(bsonData, &macCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, mac, macCopy)
 
 	testValid(t, "mac", str)
 	testInvalid(t, "mac", "01:02:03:04:05")
@@ -215,6 +264,14 @@ func TestFormatUUID3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
 
+	bsonData, err := bson.Marshal(&uuid3)
+	assert.NoError(t, err)
+
+	var uuid3Copy UUID3
+	err = bson.Unmarshal(bsonData, &uuid3Copy)
+	assert.NoError(t, err)
+	assert.Equal(t, uuid3, uuid3Copy)
+
 	testValid(t, "uuid3", str)
 	testInvalid(t, "uuid3", "not-a-uuid")
 }
@@ -242,6 +299,14 @@ func TestFormatUUID4(t *testing.T) {
 	b, err = uuid4.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	bsonData, err := bson.Marshal(&uuid4)
+	assert.NoError(t, err)
+
+	var uuid4Copy UUID4
+	err = bson.Unmarshal(bsonData, &uuid4Copy)
+	assert.NoError(t, err)
+	assert.Equal(t, uuid4, uuid4Copy)
 
 	testValid(t, "uuid4", str)
 	testInvalid(t, "uuid4", "not-a-uuid")
@@ -271,6 +336,14 @@ func TestFormatUUID5(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
 
+	bsonData, err := bson.Marshal(&uuid5)
+	assert.NoError(t, err)
+
+	var uuid5Copy UUID5
+	err = bson.Unmarshal(bsonData, &uuid5Copy)
+	assert.NoError(t, err)
+	assert.Equal(t, uuid5, uuid5Copy)
+
 	testValid(t, "uuid5", str)
 	testInvalid(t, "uuid5", "not-a-uuid")
 }
@@ -299,6 +372,14 @@ func TestFormatUUID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
 
+	bsonData, err := bson.Marshal(&uuid)
+	assert.NoError(t, err)
+
+	var uuidCopy UUID
+	err = bson.Unmarshal(bsonData, &uuidCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, uuid, uuidCopy)
+
 	testValid(t, "uuid", str)
 	testInvalid(t, "uuid", "not-a-uuid")
 }
@@ -324,6 +405,14 @@ func TestFormatISBN(t *testing.T) {
 	b, err = isbn.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	bsonData, err := bson.Marshal(&isbn)
+	assert.NoError(t, err)
+
+	var isbnCopy ISBN
+	err = bson.Unmarshal(bsonData, &isbnCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, isbn, isbnCopy)
 
 	testValid(t, "isbn", str)
 	testInvalid(t, "isbn", "836217463") // bad checksum
@@ -351,6 +440,14 @@ func TestFormatISBN10(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
 
+	bsonData, err := bson.Marshal(&isbn10)
+	assert.NoError(t, err)
+
+	var isbn10Copy ISBN10
+	err = bson.Unmarshal(bsonData, &isbn10Copy)
+	assert.NoError(t, err)
+	assert.Equal(t, isbn10, isbn10Copy)
+
 	testValid(t, "isbn10", str)
 	testInvalid(t, "isbn10", "836217463") // bad checksum
 }
@@ -376,6 +473,14 @@ func TestFormatISBN13(t *testing.T) {
 	b, err = isbn13.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	bsonData, err := bson.Marshal(&isbn13)
+	assert.NoError(t, err)
+
+	var isbn13Copy ISBN13
+	err = bson.Unmarshal(bsonData, &isbn13Copy)
+	assert.NoError(t, err)
+	assert.Equal(t, isbn13, isbn13Copy)
 
 	testValid(t, "isbn13", str)
 	testInvalid(t, "isbn13", "978-0321751042") // bad checksum
@@ -403,6 +508,14 @@ func TestFormatHexColor(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
 
+	bsonData, err := bson.Marshal(&hexColor)
+	assert.NoError(t, err)
+
+	var hexColorCopy HexColor
+	err = bson.Unmarshal(bsonData, &hexColorCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, hexColor, hexColorCopy)
+
 	testValid(t, "hexcolor", str)
 	testInvalid(t, "hexcolor", "#fffffffz")
 }
@@ -428,6 +541,14 @@ func TestFormatRGBColor(t *testing.T) {
 	b, err = rgbColor.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	bsonData, err := bson.Marshal(&rgbColor)
+	assert.NoError(t, err)
+
+	var rgbColorCopy RGBColor
+	err = bson.Unmarshal(bsonData, &rgbColorCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, rgbColor, rgbColorCopy)
 
 	testValid(t, "rgbcolor", str)
 	testInvalid(t, "rgbcolor", "rgb(300,0,0)")
@@ -455,6 +576,14 @@ func TestFormatSSN(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
 
+	bsonData, err := bson.Marshal(&ssn)
+	assert.NoError(t, err)
+
+	var ssnCopy SSN
+	err = bson.Unmarshal(bsonData, &ssnCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, ssn, ssnCopy)
+
 	testValid(t, "ssn", str)
 	testInvalid(t, "ssn", "999 99 999")
 }
@@ -480,6 +609,14 @@ func TestFormatCreditCard(t *testing.T) {
 	b, err = creditCard.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	bsonData, err := bson.Marshal(&creditCard)
+	assert.NoError(t, err)
+
+	var creditCardCopy CreditCard
+	err = bson.Unmarshal(bsonData, &creditCardCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, creditCard, creditCardCopy)
 
 	testValid(t, "creditcard", str)
 	testInvalid(t, "creditcard", "9999-9999-9999-999") // bad checksum
@@ -507,6 +644,14 @@ func TestFormatPassword(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
 
+	bsonData, err := bson.Marshal(&password)
+	assert.NoError(t, err)
+
+	var passwordCopy Password
+	err = bson.Unmarshal(bsonData, &passwordCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, password, passwordCopy)
+
 	// everything is valid
 	testValid(t, "password", str)
 }
@@ -532,6 +677,14 @@ func TestFormatBase64(t *testing.T) {
 	b, err = b64.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	bsonData, err := bson.Marshal(&b64)
+	assert.NoError(t, err)
+
+	var b64Copy Base64
+	err = bson.Unmarshal(bsonData, &b64Copy)
+	assert.NoError(t, err)
+	assert.Equal(t, b64, b64Copy)
 
 	testValid(t, "byte", str)
 	testInvalid(t, "byte", "ZWxpemFiZXRocG9zZXk") // missing pad char

--- a/duration.go
+++ b/duration.go
@@ -16,11 +16,14 @@ package strfmt
 
 import (
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
@@ -170,4 +173,22 @@ func (d *Duration) UnmarshalEasyJSON(in *jlexer.Lexer) {
 		}
 		*d = Duration(tt)
 	}
+}
+
+func (d *Duration) GetBSON() (interface{}, error) {
+	return bson.M{"data": int64(*d)}, nil
+}
+
+func (d *Duration) SetBSON(raw bson.Raw) error {
+	var m bson.M
+	if err := raw.Unmarshal(&m); err != nil {
+		return err
+	}
+
+	if data, ok := m["data"].(int64); ok {
+		*d = Duration(data)
+		return nil
+	}
+
+	return errors.New("couldn't unmarshal bson raw value as Duration")
 }

--- a/duration_test.go
+++ b/duration_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/mgo.v2/bson"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,6 +49,15 @@ func TestDuration(t *testing.T) {
 	b, err = pp.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, bj, b)
+
+	dur := Duration(42)
+	bsonData, err := bson.Marshal(&dur)
+	assert.NoError(t, err)
+
+	var durCopy Duration
+	err = bson.Unmarshal(bsonData, &durCopy)
+	assert.NoError(t, err)
+	assert.Equal(t, dur, durCopy)
 }
 
 func testDurationParser(t *testing.T, toParse string, expected time.Duration) {

--- a/time_test.go
+++ b/time_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/mgo.v2/bson"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -133,5 +135,20 @@ func TestDateTime_Scan(t *testing.T) {
 		err := pp.Scan(example.in)
 		assert.NoError(t, err)
 		assert.Equal(t, DateTime(example.time), pp)
+	}
+}
+
+func TestDateTime_BSON(t *testing.T) {
+	for caseNum, example := range testCases {
+		t.Logf("Case #%d", caseNum)
+		dt := DateTime(example.time)
+
+		bsonData, err := bson.Marshal(&dt)
+		assert.NoError(t, err)
+
+		var dtCopy DateTime
+		err = bson.Unmarshal(bsonData, &dtCopy)
+		assert.NoError(t, err)
+		assert.Equal(t, dt, dtCopy)
 	}
 }


### PR DESCRIPTION
- Make All Types Compatible with mgo.bson;
- Add ObjectId type, wrapping around mgo.bson.ObjectId (once this is merged we need to update go-swagger so that we can add support for this type);

Closes/Fixes:

- https://github.com/go-openapi/strfmt/issues/11
- https://github.com/go-openapi/strfmt/pull/7
- https://github.com/go-swagger/go-swagger/issues/670

Implements one proposal from https://github.com/go-swagger/go-swagger/issues/884