### PR TITLE
Fixes #13. Adding cast to time.Time for sql.Value calls for non-reflecting drivers

### DIFF
--- a/date.go
+++ b/date.go
@@ -102,7 +102,7 @@ func (d *Date) Scan(raw interface{}) error {
 
 // Value converts Date to a primitive value ready to written to a database.
 func (d Date) Value() (driver.Value, error) {
-	return driver.Value(d), nil
+	return driver.Value(time.Time(d)), nil
 }
 
 func (t Date) MarshalJSON() ([]byte, error) {

--- a/time.go
+++ b/time.go
@@ -135,7 +135,7 @@ func (t *DateTime) Scan(raw interface{}) error {
 
 // Value converts DateTime to a primitive value ready to written to a database.
 func (t DateTime) Value() (driver.Value, error) {
-	return driver.Value(t), nil
+	return driver.Value(time.Time(t)), nil
 }
 
 func (t DateTime) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Some SQL drivers do not do deep reflection and result in errors like:

```
"sql: converting Exec argument $2 type: non-Value type strfmt.DateTime returned from Value"
```

This proposed fix simply does an explicit cast to time.Time in these structs.