### PR TITLE
Fixes #13. Fixing SQL Value to store casted time.Time value as RFC3339Millis

### DIFF
--- a/date.go
+++ b/date.go
@@ -102,7 +102,7 @@ func (d *Date) Scan(raw interface{}) error {
 
 // Value converts Date to a primitive value ready to written to a database.
 func (d Date) Value() (driver.Value, error) {
-	return driver.Value(time.Time(d)), nil
+	return driver.Value(time.Time(d).Format(RFC3339Millis)), nil
 }
 
 func (t Date) MarshalJSON() ([]byte, error) {

--- a/date.go
+++ b/date.go
@@ -102,7 +102,7 @@ func (d *Date) Scan(raw interface{}) error {
 
 // Value converts Date to a primitive value ready to written to a database.
 func (d Date) Value() (driver.Value, error) {
-	return driver.Value(time.Time(d).Format(RFC3339Millis)), nil
+	return driver.Value(d.String()), nil
 }
 
 func (t Date) MarshalJSON() ([]byte, error) {

--- a/date.go
+++ b/date.go
@@ -102,7 +102,7 @@ func (d *Date) Scan(raw interface{}) error {
 
 // Value converts Date to a primitive value ready to written to a database.
 func (d Date) Value() (driver.Value, error) {
-	return driver.Value(d), nil
+	return driver.Value(time.Time(d)), nil
 }
 
 func (t Date) MarshalJSON() ([]byte, error) {

--- a/date_test.go
+++ b/date_test.go
@@ -79,5 +79,5 @@ func TestDate_Value(t *testing.T) {
 	date := Date(ref)
 	dbv, err := date.Value()
 	assert.NoError(t, err)
-	assert.EqualValues(t, dbv, ref)
+	assert.EqualValues(t, dbv, ref.Format("2006-01-02"))
 }

--- a/time.go
+++ b/time.go
@@ -135,7 +135,7 @@ func (t *DateTime) Scan(raw interface{}) error {
 
 // Value converts DateTime to a primitive value ready to written to a database.
 func (t DateTime) Value() (driver.Value, error) {
-	return driver.Value(time.Time(t).Format(RFC3339Millis)), nil
+	return driver.Value(t.String()), nil
 }
 
 func (t DateTime) MarshalJSON() ([]byte, error) {

--- a/time.go
+++ b/time.go
@@ -135,7 +135,7 @@ func (t *DateTime) Scan(raw interface{}) error {
 
 // Value converts DateTime to a primitive value ready to written to a database.
 func (t DateTime) Value() (driver.Value, error) {
-	return driver.Value(t), nil
+	return driver.Value(time.Time(t)), nil
 }
 
 func (t DateTime) MarshalJSON() ([]byte, error) {

--- a/time.go
+++ b/time.go
@@ -135,7 +135,7 @@ func (t *DateTime) Scan(raw interface{}) error {
 
 // Value converts DateTime to a primitive value ready to written to a database.
 func (t DateTime) Value() (driver.Value, error) {
-	return driver.Value(time.Time(t)), nil
+	return driver.Value(time.Time(t).Format(RFC3339Millis)), nil
 }
 
 func (t DateTime) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Previous PR:https://github.com/go-openapi/strfmt/pull/14 didn't save the time as RFC3339Millis which is expected by the SQL Scan.