### PR TITLE
Add support for microsecond precision and allow marshalling format to be overridden

### DIFF
--- a/time.go
+++ b/time.go
@@ -62,6 +62,7 @@ const (
 var (
 	dateTimeFormats = []string{RFC3339Millis, time.RFC3339, time.RFC3339Nano}
 	rxDateTime      = regexp.MustCompile(DateTimePattern)
+	MarshalFormat   = RFC3339Millis
 )
 
 // ParseDateTime parses a string that represents an ISO8601 time or a unix epoch
@@ -96,7 +97,7 @@ func NewDateTime() DateTime {
 }
 
 func (t DateTime) String() string {
-	return time.Time(t).Format(RFC3339Millis)
+	return time.Time(t).Format(MarshalFormat)
 }
 
 // MarshalText implements the text marshaller interface
@@ -145,7 +146,7 @@ func (t DateTime) MarshalJSON() ([]byte, error) {
 }
 
 func (t DateTime) MarshalEasyJSON(w *jwriter.Writer) {
-	w.String(time.Time(t).Format(RFC3339Millis))
+	w.String(time.Time(t).Format(MarshalFormat))
 }
 
 func (t *DateTime) UnmarshalJSON(data []byte) error {

--- a/time.go
+++ b/time.go
@@ -55,12 +55,14 @@ func IsDateTime(str string) bool {
 const (
 	// RFC3339Millis represents a ISO8601 format to millis instead of to nanos
 	RFC3339Millis = "2006-01-02T15:04:05.000Z07:00"
+	// RFC3339Micro represents a ISO8601 format to micro instead of to nano
+	RFC3339Micro = "2006-01-02T15:04:05.000000Z07:00"
 	// DateTimePattern pattern to match for the date-time format from http://tools.ietf.org/html/rfc3339#section-5.6
 	DateTimePattern = `^([0-9]{2}):([0-9]{2}):([0-9]{2})(.[0-9]+)?(z|([+-][0-9]{2}:[0-9]{2}))$`
 )
 
 var (
-	dateTimeFormats = []string{RFC3339Millis, time.RFC3339, time.RFC3339Nano}
+	dateTimeFormats = []string{RFC3339Micro, RFC3339Millis, time.RFC3339, time.RFC3339Nano}
 	rxDateTime      = regexp.MustCompile(DateTimePattern)
 	MarshalFormat   = RFC3339Millis
 )


### PR DESCRIPTION
This basically allows users to set the marshalling format by setting `strfmt.MarshalFormat` to their desired format.