### PR TITLE
Fix str->bson function usages

### DIFF
--- a/bson.go
+++ b/bson.go
@@ -33,8 +33,7 @@ func init() {
 
 // IsBSONObjectID returns true when the string is a valid BSON.ObjectId
 func IsBSONObjectID(str string) bool {
-	var id bson.ObjectId
-	return id.UnmarshalText([]byte(str)) == nil
+	return bson.IsObjectIdHex(str)
 }
 
 // ObjectId represents a BSON object ID (alias to gopkg.in/mgo.v2/bson.ObjectId)
@@ -54,12 +53,7 @@ func (id *ObjectId) MarshalText() ([]byte, error) {
 
 // UnmarshalText hydrates this instance from text
 func (id *ObjectId) UnmarshalText(data []byte) error { // validation is performed later on
-	var rawID bson.ObjectId
-	if err := rawID.UnmarshalText(data); err != nil {
-		return err
-	}
-
-	*id = ObjectId(rawID)
+	*id = ObjectId(bson.ObjectIdHex(string(data)))
 	return nil
 }
 


### PR DESCRIPTION
It appears `bson.ObjectId.UnmarshalText` was removed in favor of `bson.IsObjectIdHex` and `bson.ObjectIdHex`.