### PR TITLE
Handle null uuids when deserializing

### DIFF
--- a/default.go
+++ b/default.go
@@ -862,6 +862,9 @@ func (u UUID) MarshalEasyJSON(w *jwriter.Writer) {
 
 // UnmarshalJSON sets the UUID from JSON
 func (u *UUID) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
 	l := jlexer.Lexer{Data: data}
 	u.UnmarshalEasyJSON(&l)
 	return l.Error()
@@ -947,6 +950,9 @@ func (u UUID3) MarshalEasyJSON(w *jwriter.Writer) {
 
 // UnmarshalJSON sets the UUID3 from JSON
 func (u *UUID3) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
 	l := jlexer.Lexer{Data: data}
 	u.UnmarshalEasyJSON(&l)
 	return l.Error()
@@ -1032,6 +1038,9 @@ func (u UUID4) MarshalEasyJSON(w *jwriter.Writer) {
 
 // UnmarshalJSON sets the UUID4 from JSON
 func (u *UUID4) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
 	l := jlexer.Lexer{Data: data}
 	u.UnmarshalEasyJSON(&l)
 	return l.Error()
@@ -1117,6 +1126,9 @@ func (u UUID5) MarshalEasyJSON(w *jwriter.Writer) {
 
 // UnmarshalJSON sets the UUID5 from JSON
 func (u *UUID5) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
 	l := jlexer.Lexer{Data: data}
 	u.UnmarshalEasyJSON(&l)
 	return l.Error()

--- a/default_test.go
+++ b/default_test.go
@@ -274,6 +274,11 @@ func TestFormatUUID3(t *testing.T) {
 
 	testValid(t, "uuid3", str)
 	testInvalid(t, "uuid3", "not-a-uuid")
+
+	var uuidZero UUID3
+	err = uuidZero.UnmarshalJSON([]byte("null"))
+	assert.NoError(t, err)
+	assert.EqualValues(t, UUID3(""), uuidZero)
 }
 
 func TestFormatUUID4(t *testing.T) {
@@ -310,6 +315,11 @@ func TestFormatUUID4(t *testing.T) {
 
 	testValid(t, "uuid4", str)
 	testInvalid(t, "uuid4", "not-a-uuid")
+
+	var uuidZero UUID4
+	err = uuidZero.UnmarshalJSON([]byte("null"))
+	assert.NoError(t, err)
+	assert.EqualValues(t, UUID4(""), uuidZero)
 }
 
 func TestFormatUUID5(t *testing.T) {
@@ -346,6 +356,11 @@ func TestFormatUUID5(t *testing.T) {
 
 	testValid(t, "uuid5", str)
 	testInvalid(t, "uuid5", "not-a-uuid")
+
+	var uuidZero UUID5
+	err = uuidZero.UnmarshalJSON([]byte("null"))
+	assert.NoError(t, err)
+	assert.EqualValues(t, UUID5(""), uuidZero)
 }
 
 func TestFormatUUID(t *testing.T) {
@@ -382,6 +397,11 @@ func TestFormatUUID(t *testing.T) {
 
 	testValid(t, "uuid", str)
 	testInvalid(t, "uuid", "not-a-uuid")
+
+	var uuidZero UUID
+	err = uuidZero.UnmarshalJSON([]byte("null"))
+	assert.NoError(t, err)
+	assert.EqualValues(t, UUID(""), uuidZero)
 }
 
 func TestFormatISBN(t *testing.T) {


### PR DESCRIPTION
#26  - When deserializing UUIDs, allow null values in the json. This results
 in creating Zero UUID instead of failing deserialization.

Github Issue: https://github.com/go-openapi/strfmt/issues/26

Signed-off-by: Prem Ramanathan <premram@google.com>