### PR TITLE
Handle null dates when deserializing

### DIFF
--- a/date.go
+++ b/date.go
@@ -109,6 +109,9 @@ func (d Date) MarshalEasyJSON(w *jwriter.Writer) {
 
 // UnmarshalJSON sets the Date from JSON
 func (d *Date) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
 	l := jlexer.Lexer{Data: data}
 	d.UnmarshalEasyJSON(&l)
 	return l.Error()

--- a/date_test.go
+++ b/date_test.go
@@ -65,6 +65,11 @@ func TestDate(t *testing.T) {
 	err = bson.Unmarshal(bsonData, &dateCopy)
 	assert.NoError(t, err)
 	assert.Equal(t, dateOriginal, dateCopy)
+
+	var dateZero Date
+	err = dateZero.UnmarshalJSON([]byte("null"))
+	assert.NoError(t, err)
+	assert.Equal(t, Date{}, dateZero)
 }
 
 func TestDate_Scan(t *testing.T) {


### PR DESCRIPTION
When deserializing, ignore null dates instead of failing.
This makes null values semantically equivalent to missing field
(undefined).

Signed-off-by: Prem Ramanathan <premram@google.com>