### PR TITLE
Fixes #36 Hostname matching doesn't conform to modern hostname patterns

### DIFF
--- a/default.go
+++ b/default.go
@@ -49,7 +49,7 @@ const (
 	//  <subdomain> ::= <label> | <subdomain> "." <label>
 	//  var subdomain = /^[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?(\.[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?)*$/;
 	//  <domain> ::= <subdomain> | " "
-	HostnamePattern = `^[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?(\.[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?)*$`
+	HostnamePattern = `^[a-zA-Z0-9](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?(\.[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?)*$`
 	// UUIDPattern Regex for UUID that allows uppercase
 	UUIDPattern = `(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$`
 	// UUID3Pattern Regex for UUID3 that allows uppercase

--- a/default_test.go
+++ b/default_test.go
@@ -73,7 +73,12 @@ func TestFormatHostname(t *testing.T) {
 		veryLongStr,
 		longAddrSegment,
 	}
+	validHostnames := []string{
+		"somewhere.com",
+		"888.com",
+	}
 	testStringFormat(t, &hostname, "hostname", str, []string{}, invalidHostnames)
+	testStringFormat(t, &hostname, "hostname", str, validHostnames, []string{})
 }
 
 func TestFormatIPv4(t *testing.T) {


### PR DESCRIPTION
This PR introduces a change to the regex which allows for Hostnames to start with a number.

I have added a test for two valid domains which currently pass.

Signed-off-by: James Lamb <jlamb@atlassian.com>