### PR TITLE
add unicode (emoji) and puny code domain support to hostname validation

### DIFF
--- a/default.go
+++ b/default.go
@@ -49,7 +49,7 @@ const (
 	//  <subdomain> ::= <label> | <subdomain> "." <label>
 	//  var subdomain = /^[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?(\.[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?)*$/;
 	//  <domain> ::= <subdomain> | " "
-	HostnamePattern = `^[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?(\.[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?)*$`
+	HostnamePattern = `^[a-zA-Z0-9\p{S}](([a-zA-Z0-9-\p{S}]{0,63})(\.)){0,6}([a-zA-Z]){2,3}$`
 	// UUIDPattern Regex for UUID that allows uppercase
 	UUIDPattern = `(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$`
 	// UUID3Pattern Regex for UUID3 that allows uppercase

--- a/default_test.go
+++ b/default_test.go
@@ -73,7 +73,26 @@ func TestFormatHostname(t *testing.T) {
 		veryLongStr,
 		longAddrSegment,
 	}
+	validHostnames := []string{
+		"a.com",
+		"a.b.com",
+		"a.b.c.com",
+		"a.b.c.d.com",
+		"a.b.c.d.e.com",
+		"1.com",
+		"1.2.com",
+		"1.2.3.com",
+		"1.2.3.4.com",
+		"99.domain.com",
+		"99.99.domain.com",
+		"888.com",
+		"xn-80ak6aa92e.co",
+		"xn-80ak6aa92e.com",
+		"xn--ls8h.la",
+		"☁→❄→☃→☀→☺→☂→☹→✝.ws",
+	}
 	testStringFormat(t, &hostname, "hostname", str, []string{}, invalidHostnames)
+	testStringFormat(t, &hostname, "hostname", str, validHostnames, []string{})
 }
 
 func TestFormatIPv4(t *testing.T) {


### PR DESCRIPTION
This pull request extends on my previous regex changes for the hostname validation.
* adds puny code validation
* supports unicode (emoji) domain checking
* adds tests to validate various levels of nested domains we faced in production.