### PR TITLE
add unicode (emoji) and puny code domain support to hostname validation

### DIFF
--- a/default.go
+++ b/default.go
@@ -49,11 +49,7 @@ const (
 	//  <subdomain> ::= <label> | <subdomain> "." <label>
 	//  var subdomain = /^[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?(\.[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?)*$/;
 	//  <domain> ::= <subdomain> | " "
-<<<<<<< HEAD
-	HostnamePattern = `^[a-zA-Z0-9](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?(\.[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?)*$`
-=======
 	HostnamePattern = `^[a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,63})(\.)){1,6}([a-zA-Z\p{L}]){2,}$`
->>>>>>> fix regex to allow non-ascii and long tlds
 	// UUIDPattern Regex for UUID that allows uppercase
 	UUIDPattern = `(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$`
 	// UUID3Pattern Regex for UUID3 that allows uppercase

--- a/default.go
+++ b/default.go
@@ -49,7 +49,11 @@ const (
 	//  <subdomain> ::= <label> | <subdomain> "." <label>
 	//  var subdomain = /^[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?(\.[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?)*$/;
 	//  <domain> ::= <subdomain> | " "
+<<<<<<< HEAD
 	HostnamePattern = `^[a-zA-Z0-9](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?(\.[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?)*$`
+=======
+	HostnamePattern = `^[a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,63})(\.)){1,6}([a-zA-Z\p{L}]){2,}$`
+>>>>>>> fix regex to allow non-ascii and long tlds
 	// UUIDPattern Regex for UUID that allows uppercase
 	UUIDPattern = `(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$`
 	// UUID3Pattern Regex for UUID3 that allows uppercase

--- a/default_test.go
+++ b/default_test.go
@@ -72,8 +72,12 @@ func TestFormatHostname(t *testing.T) {
 		"somewhere.com!",
 		veryLongStr,
 		longAddrSegment,
+		"user@email.domain",
+		"1.1.1.1",
 	}
 	validHostnames := []string{
+		"somewhere.com",
+		"888.com",
 		"a.com",
 		"a.b.com",
 		"a.b.c.com",
@@ -85,11 +89,14 @@ func TestFormatHostname(t *testing.T) {
 		"1.2.3.4.com",
 		"99.domain.com",
 		"99.99.domain.com",
-		"888.com",
 		"xn-80ak6aa92e.co",
 		"xn-80ak6aa92e.com",
 		"xn--ls8h.la",
 		"☁→❄→☃→☀→☺→☂→☹→✝.ws",
+		"www.example.onion",
+		"www.example.ôlà",
+		"ôlà.ôlà",
+		"ôlà.ôlà.ôlà",
 	}
 	testStringFormat(t, &hostname, "hostname", str, []string{}, invalidHostnames)
 	testStringFormat(t, &hostname, "hostname", str, validHostnames, []string{})

--- a/default_test.go
+++ b/default_test.go
@@ -74,8 +74,22 @@ func TestFormatHostname(t *testing.T) {
 		longAddrSegment,
 	}
 	validHostnames := []string{
-		"somewhere.com",
+		"a.com",
+		"a.b.com",
+		"a.b.c.com",
+		"a.b.c.d.com",
+		"a.b.c.d.e.com",
+		"1.com",
+		"1.2.com",
+		"1.2.3.com",
+		"1.2.3.4.com",
+		"99.domain.com",
+		"99.99.domain.com",
 		"888.com",
+		"xn-80ak6aa92e.co",
+		"xn-80ak6aa92e.com",
+		"xn--ls8h.la",
+		"☁→❄→☃→☀→☺→☂→☹→✝.ws",
 	}
 	testStringFormat(t, &hostname, "hostname", str, []string{}, invalidHostnames)
 	testStringFormat(t, &hostname, "hostname", str, validHostnames, []string{})

--- a/default_test.go
+++ b/default_test.go
@@ -70,10 +70,10 @@ func TestFormatHostname(t *testing.T) {
 	longAddrSegment := strings.Join([]string{"x", "y", longStr}, ".")
 	invalidHostnames := []string{
 		"somewhere.com!",
-		veryLongStr,
-		longAddrSegment,
 		"user@email.domain",
 		"1.1.1.1",
+		veryLongStr,
+		longAddrSegment,
 	}
 	validHostnames := []string{
 		"somewhere.com",
@@ -98,6 +98,7 @@ func TestFormatHostname(t *testing.T) {
 		"ôlà.ôlà",
 		"ôlà.ôlà.ôlà",
 	}
+
 	testStringFormat(t, &hostname, "hostname", str, []string{}, invalidHostnames)
 	testStringFormat(t, &hostname, "hostname", str, validHostnames, []string{})
 }


### PR DESCRIPTION
Updated PR as my previous one had merge checks because it didn't sync properly 🤦‍♂️ 

This pull request adds support for puny and unicode special character domains to the Hostname validation regex.
* adds tests for the various nesting examples we have been exposed to so far
* adds tests for crazy unicode emoji domain
* adds numerical domains with nesting