### PR TITLE
Fix hostname validation regexp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,3 +18,5 @@ linters:
   disable:
     - maligned
     - lll
+    - gochecknoinits
+    - gochecknoglobals

--- a/default.go
+++ b/default.go
@@ -49,7 +49,15 @@ const (
 	//  <subdomain> ::= <label> | <subdomain> "." <label>
 	//  var subdomain = /^[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?(\.[a-zA-Z](([-0-9a-zA-Z]+)?[0-9a-zA-Z])?)*$/;
 	//  <domain> ::= <subdomain> | " "
-	HostnamePattern = `^[a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,63})(\.)){1,6}([a-zA-Z\p{L}]){2,}$`
+	//
+	// Additional validations:
+	//   - for FDQNs, top-level domain (e.g. ".com"), is at least to letters long (no special characters here)
+	//   - hostnames may start with a digit [RFC1123]
+	//   - special registered names with an underscore ('_') are not allowed in this context
+	//   - dashes are permitted, but not at the start or the end of a segment
+	//   - long top-level domain names (e.g. example.london) are permitted
+	//   - symbol unicode points are permitted (e.g. emoji) (not for top-level domain)
+	HostnamePattern = `^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$`
 	// UUIDPattern Regex for UUID that allows uppercase
 	UUIDPattern = `(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$`
 	// UUID3Pattern Regex for UUID3 that allows uppercase

--- a/default_test.go
+++ b/default_test.go
@@ -74,6 +74,28 @@ func TestFormatHostname(t *testing.T) {
 		"1.1.1.1",
 		veryLongStr,
 		longAddrSegment,
+		// dashes
+		"www.example-.org",
+		"www.--example.org",
+		"-www.example.org",
+		"www-.example.org",
+		"www.d-.org",
+		"www.-d.org",
+		"www-",
+		"-www",
+		// other characters (not in symbols)
+		"www.ex ample.org",
+		"_www.example.org",
+		"www.ex;ample.org",
+		"www.example_underscored.org",
+		// short top-level domains
+		"www.詹姆斯.x",
+		"a.b.c.d",
+		"-xyz",
+		"xyz-",
+		"x.",
+		"a.b.c.dot-",
+		"a.b.c.é;ö",
 	}
 	validHostnames := []string{
 		"somewhere.com",
@@ -89,6 +111,9 @@ func TestFormatHostname(t *testing.T) {
 		"1.2.3.4.com",
 		"99.domain.com",
 		"99.99.domain.com",
+		"1wwworg.example.com", // valid, per RFC1123
+		"1000wwworg.example.com",
+		"xn--bcher-kva.example.com", // puny encoded
 		"xn-80ak6aa92e.co",
 		"xn-80ak6aa92e.com",
 		"xn--ls8h.la",
@@ -97,6 +122,23 @@ func TestFormatHostname(t *testing.T) {
 		"www.example.ôlà",
 		"ôlà.ôlà",
 		"ôlà.ôlà.ôlà",
+		"ex$ample",
+		"localhost",
+		"example",
+		"x",
+		"x-y",
+		"a.b.c.dot",
+		"www.example.org",
+		"a.b.c.d.e.f.g.dot",
+		// extended symbol alphabet
+		"ex=ample.com",
+		"<foo>",
+		"www.example-hyphenated.org",
+		// localized hostnames
+		"www.詹姆斯.org",
+		"www.élégigôö.org",
+		// long top-level domains
+		"www.詹姆斯.london",
 	}
 
 	testStringFormat(t, &hostname, "hostname", str, []string{}, invalidHostnames)


### PR DESCRIPTION
* fixes #42 (simple hostnames, not necessarily FDQNs)
* adds more tests for hostname validations

Validation rules are:
  * internationalized (unicode) hostnames are permitted
  * for FDQNs, top-level domain (e.g. ".com"), is at least to letters long (no special characters here)
  * hostnames may start with a digit [RFC1123]
  * special registered names with an underscore ('_') are not allowed in this context
  * dashes are permitted, but not at the start or the end of a segment
  * long top-level domain names (e.g. example.london) are permitted
  * symbol unicode points are permitted (e.g. emoji) (not for top-level domain)

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>