### PR TITLE
Add DeepCopy and DeepCopyInto methods to all types

### DIFF
--- a/bson.go
+++ b/bson.go
@@ -125,3 +125,19 @@ func (id *ObjectId) SetBSON(raw bson.Raw) error {
 
 	return errors.New("couldn't unmarshal bson raw value as ObjectId")
 }
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *ObjectId) DeepCopyInto(out *ObjectId) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new ObjectId.
+func (in *ObjectId) DeepCopy() *ObjectId {
+	if in == nil {
+		return nil
+	}
+	out := new(ObjectId)
+	in.DeepCopyInto(out)
+	return out
+}

--- a/bson_test.go
+++ b/bson_test.go
@@ -50,3 +50,19 @@ func TestBSONObjectId_fullCycle(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, id, idCopy)
 }
+
+func TestDeepCopyObjectId(t *testing.T) {
+	id := NewObjectId("507f1f77bcf86cd799439011")
+	in := &id
+
+	out := new(ObjectId)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *ObjectId
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}

--- a/date.go
+++ b/date.go
@@ -148,3 +148,19 @@ func (d *Date) SetBSON(raw bson.Raw) error {
 
 	return errors.New("couldn't unmarshal bson raw value as Date")
 }
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *Date) DeepCopyInto(out *Date) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new Date.
+func (in *Date) DeepCopy() *Date {
+	if in == nil {
+		return nil
+	}
+	out := new(Date)
+	in.DeepCopyInto(out)
+	return out
+}

--- a/date_test.go
+++ b/date_test.go
@@ -122,3 +122,20 @@ func TestDate_IsDate(t *testing.T) {
 		assert.Equal(t, test.valid, IsDate(test.value), "value [%s] should be valid: [%t]", test.value, test.valid)
 	}
 }
+
+func TestDeepCopyDate(t *testing.T) {
+	ref := time.Now().Truncate(24 * time.Hour).UTC()
+	date := Date(ref)
+	in := &date
+
+	out := new(Date)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *Date
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}

--- a/default.go
+++ b/default.go
@@ -311,6 +311,22 @@ func (b *Base64) SetBSON(raw bson.Raw) error {
 	return errors.New("couldn't unmarshal bson raw value as Base64")
 }
 
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *Base64) DeepCopyInto(out *Base64) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new Base64.
+func (in *Base64) DeepCopy() *Base64 {
+	if in == nil {
+		return nil
+	}
+	out := new(Base64)
+	in.DeepCopyInto(out)
+	return out
+}
+
 // URI represents the uri string format as specified by the json schema spec
 //
 // swagger:strfmt uri
@@ -394,6 +410,22 @@ func (u *URI) SetBSON(raw bson.Raw) error {
 	}
 
 	return errors.New("couldn't unmarshal bson raw value as URI")
+}
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *URI) DeepCopyInto(out *URI) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new URI.
+func (in *URI) DeepCopy() *URI {
+	if in == nil {
+		return nil
+	}
+	out := new(URI)
+	in.DeepCopyInto(out)
+	return out
 }
 
 // Email represents the email string format as specified by the json schema spec
@@ -481,6 +513,22 @@ func (e *Email) SetBSON(raw bson.Raw) error {
 	return errors.New("couldn't unmarshal bson raw value as Email")
 }
 
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *Email) DeepCopyInto(out *Email) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new Email.
+func (in *Email) DeepCopy() *Email {
+	if in == nil {
+		return nil
+	}
+	out := new(Email)
+	in.DeepCopyInto(out)
+	return out
+}
+
 // Hostname represents the hostname string format as specified by the json schema spec
 //
 // swagger:strfmt hostname
@@ -564,6 +612,22 @@ func (h *Hostname) SetBSON(raw bson.Raw) error {
 	}
 
 	return errors.New("couldn't unmarshal bson raw value as Hostname")
+}
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *Hostname) DeepCopyInto(out *Hostname) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new Hostname.
+func (in *Hostname) DeepCopy() *Hostname {
+	if in == nil {
+		return nil
+	}
+	out := new(Hostname)
+	in.DeepCopyInto(out)
+	return out
 }
 
 // IPv4 represents an IP v4 address
@@ -651,6 +715,22 @@ func (u *IPv4) SetBSON(raw bson.Raw) error {
 	return errors.New("couldn't unmarshal bson raw value as IPv4")
 }
 
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *IPv4) DeepCopyInto(out *IPv4) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new IPv4.
+func (in *IPv4) DeepCopy() *IPv4 {
+	if in == nil {
+		return nil
+	}
+	out := new(IPv4)
+	in.DeepCopyInto(out)
+	return out
+}
+
 // IPv6 represents an IP v6 address
 //
 // swagger:strfmt ipv6
@@ -736,6 +816,22 @@ func (u *IPv6) SetBSON(raw bson.Raw) error {
 	return errors.New("couldn't unmarshal bson raw value as IPv6")
 }
 
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *IPv6) DeepCopyInto(out *IPv6) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new IPv6.
+func (in *IPv6) DeepCopy() *IPv6 {
+	if in == nil {
+		return nil
+	}
+	out := new(IPv6)
+	in.DeepCopyInto(out)
+	return out
+}
+
 // MAC represents a 48 bit MAC address
 //
 // swagger:strfmt mac
@@ -819,6 +915,22 @@ func (u *MAC) SetBSON(raw bson.Raw) error {
 	}
 
 	return errors.New("couldn't unmarshal bson raw value as MAC")
+}
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *MAC) DeepCopyInto(out *MAC) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new MAC.
+func (in *MAC) DeepCopy() *MAC {
+	if in == nil {
+		return nil
+	}
+	out := new(MAC)
+	in.DeepCopyInto(out)
+	return out
 }
 
 // UUID represents a uuid string format
@@ -909,6 +1021,22 @@ func (u *UUID) SetBSON(raw bson.Raw) error {
 	return errors.New("couldn't unmarshal bson raw value as UUID")
 }
 
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *UUID) DeepCopyInto(out *UUID) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new UUID.
+func (in *UUID) DeepCopy() *UUID {
+	if in == nil {
+		return nil
+	}
+	out := new(UUID)
+	in.DeepCopyInto(out)
+	return out
+}
+
 // UUID3 represents a uuid3 string format
 //
 // swagger:strfmt uuid3
@@ -995,6 +1123,22 @@ func (u *UUID3) SetBSON(raw bson.Raw) error {
 	}
 
 	return errors.New("couldn't unmarshal bson raw value as UUID3")
+}
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *UUID3) DeepCopyInto(out *UUID3) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new UUID3.
+func (in *UUID3) DeepCopy() *UUID3 {
+	if in == nil {
+		return nil
+	}
+	out := new(UUID3)
+	in.DeepCopyInto(out)
+	return out
 }
 
 // UUID4 represents a uuid4 string format
@@ -1085,6 +1229,22 @@ func (u *UUID4) SetBSON(raw bson.Raw) error {
 	return errors.New("couldn't unmarshal bson raw value as UUID4")
 }
 
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *UUID4) DeepCopyInto(out *UUID4) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new UUID4.
+func (in *UUID4) DeepCopy() *UUID4 {
+	if in == nil {
+		return nil
+	}
+	out := new(UUID4)
+	in.DeepCopyInto(out)
+	return out
+}
+
 // UUID5 represents a uuid5 string format
 //
 // swagger:strfmt uuid5
@@ -1173,6 +1333,22 @@ func (u *UUID5) SetBSON(raw bson.Raw) error {
 	return errors.New("couldn't unmarshal bson raw value as UUID5")
 }
 
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *UUID5) DeepCopyInto(out *UUID5) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new UUID5.
+func (in *UUID5) DeepCopy() *UUID5 {
+	if in == nil {
+		return nil
+	}
+	out := new(UUID5)
+	in.DeepCopyInto(out)
+	return out
+}
+
 // ISBN represents an isbn string format
 //
 // swagger:strfmt isbn
@@ -1256,6 +1432,22 @@ func (u *ISBN) SetBSON(raw bson.Raw) error {
 	}
 
 	return errors.New("couldn't unmarshal bson raw value as ISBN")
+}
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *ISBN) DeepCopyInto(out *ISBN) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new ISBN.
+func (in *ISBN) DeepCopy() *ISBN {
+	if in == nil {
+		return nil
+	}
+	out := new(ISBN)
+	in.DeepCopyInto(out)
+	return out
 }
 
 // ISBN10 represents an isbn 10 string format
@@ -1343,6 +1535,22 @@ func (u *ISBN10) SetBSON(raw bson.Raw) error {
 	return errors.New("couldn't unmarshal bson raw value as ISBN10")
 }
 
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *ISBN10) DeepCopyInto(out *ISBN10) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new ISBN10.
+func (in *ISBN10) DeepCopy() *ISBN10 {
+	if in == nil {
+		return nil
+	}
+	out := new(ISBN10)
+	in.DeepCopyInto(out)
+	return out
+}
+
 // ISBN13 represents an isbn 13 string format
 //
 // swagger:strfmt isbn13
@@ -1426,6 +1634,22 @@ func (u *ISBN13) SetBSON(raw bson.Raw) error {
 	}
 
 	return errors.New("couldn't unmarshal bson raw value as ISBN13")
+}
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *ISBN13) DeepCopyInto(out *ISBN13) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new ISBN13.
+func (in *ISBN13) DeepCopy() *ISBN13 {
+	if in == nil {
+		return nil
+	}
+	out := new(ISBN13)
+	in.DeepCopyInto(out)
+	return out
 }
 
 // CreditCard represents a credit card string format
@@ -1513,6 +1737,22 @@ func (u *CreditCard) SetBSON(raw bson.Raw) error {
 	return errors.New("couldn't unmarshal bson raw value as CreditCard")
 }
 
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *CreditCard) DeepCopyInto(out *CreditCard) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new CreditCard.
+func (in *CreditCard) DeepCopy() *CreditCard {
+	if in == nil {
+		return nil
+	}
+	out := new(CreditCard)
+	in.DeepCopyInto(out)
+	return out
+}
+
 // SSN represents a social security string format
 //
 // swagger:strfmt ssn
@@ -1596,6 +1836,22 @@ func (u *SSN) SetBSON(raw bson.Raw) error {
 	}
 
 	return errors.New("couldn't unmarshal bson raw value as SSN")
+}
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *SSN) DeepCopyInto(out *SSN) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new SSN.
+func (in *SSN) DeepCopy() *SSN {
+	if in == nil {
+		return nil
+	}
+	out := new(SSN)
+	in.DeepCopyInto(out)
+	return out
 }
 
 // HexColor represents a hex color string format
@@ -1683,6 +1939,22 @@ func (h *HexColor) SetBSON(raw bson.Raw) error {
 	return errors.New("couldn't unmarshal bson raw value as HexColor")
 }
 
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *HexColor) DeepCopyInto(out *HexColor) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new HexColor.
+func (in *HexColor) DeepCopy() *HexColor {
+	if in == nil {
+		return nil
+	}
+	out := new(HexColor)
+	in.DeepCopyInto(out)
+	return out
+}
+
 // RGBColor represents a RGB color string format
 //
 // swagger:strfmt rgbcolor
@@ -1766,6 +2038,22 @@ func (r *RGBColor) SetBSON(raw bson.Raw) error {
 	}
 
 	return errors.New("couldn't unmarshal bson raw value as RGBColor")
+}
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *RGBColor) DeepCopyInto(out *RGBColor) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new RGBColor.
+func (in *RGBColor) DeepCopy() *RGBColor {
+	if in == nil {
+		return nil
+	}
+	out := new(RGBColor)
+	in.DeepCopyInto(out)
+	return out
 }
 
 // Password represents a password.
@@ -1852,4 +2140,20 @@ func (r *Password) SetBSON(raw bson.Raw) error {
 	}
 
 	return errors.New("couldn't unmarshal bson raw value as Password")
+}
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *Password) DeepCopyInto(out *Password) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new Password.
+func (in *Password) DeepCopy() *Password {
+	if in == nil {
+		return nil
+	}
+	out := new(Password)
+	in.DeepCopyInto(out)
+	return out
 }

--- a/default_test.go
+++ b/default_test.go
@@ -434,3 +434,311 @@ func testInvalid(t *testing.T, name, value string) {
 		t.Errorf("expected %q of type %s to be invalid", value, name)
 	}
 }
+
+func TestDeepCopyBase64(t *testing.T) {
+	b64 := Base64("ZWxpemFiZXRocG9zZXk=")
+	in := &b64
+
+	out := new(Base64)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *Base64
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyURI(t *testing.T) {
+	uri := URI("http://somewhere.com")
+	in := &uri
+
+	out := new(URI)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *URI
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyEmail(t *testing.T) {
+	email := Email("somebody@somewhere.com")
+	in := &email
+
+	out := new(Email)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *Email
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyHostname(t *testing.T) {
+	hostname := Hostname("somewhere.com")
+	in := &hostname
+
+	out := new(Hostname)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *Hostname
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyIPv4(t *testing.T) {
+	ipv4 := IPv4("192.168.254.1")
+	in := &ipv4
+
+	out := new(IPv4)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *IPv4
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyIPv6(t *testing.T) {
+	ipv6 := IPv6("::1")
+	in := &ipv6
+
+	out := new(IPv6)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *IPv6
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyMAC(t *testing.T) {
+	mac := MAC("01:02:03:04:05:06")
+	in := &mac
+
+	out := new(MAC)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *MAC
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyUUID(t *testing.T) {
+	first5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhere.com"))
+	uuid := UUID(first5.String())
+	in := &uuid
+
+	out := new(UUID)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *UUID
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyUUID3(t *testing.T) {
+	first3 := uuid.NewMD5(uuid.NameSpace_URL, []byte("somewhere.com"))
+	uuid3 := UUID3(first3.String())
+	in := &uuid3
+
+	out := new(UUID3)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *UUID3
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyUUID4(t *testing.T) {
+	first4 := uuid.NewRandom()
+	uuid4 := UUID4(first4.String())
+	in := &uuid4
+
+	out := new(UUID4)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *UUID4
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyUUID5(t *testing.T) {
+	first5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhere.com"))
+	uuid5 := UUID5(first5.String())
+	in := &uuid5
+
+	out := new(UUID5)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *UUID5
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyISBN(t *testing.T) {
+	isbn := ISBN("0321751043")
+	in := &isbn
+
+	out := new(ISBN)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *ISBN
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyISBN10(t *testing.T) {
+	isbn10 := ISBN10("0321751043")
+	in := &isbn10
+
+	out := new(ISBN10)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *ISBN10
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyISBN13(t *testing.T) {
+	isbn13 := ISBN13("978-0321751041")
+	in := &isbn13
+
+	out := new(ISBN13)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *ISBN13
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyCreditCard(t *testing.T) {
+	creditCard := CreditCard("4111-1111-1111-1111")
+	in := &creditCard
+
+	out := new(CreditCard)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *CreditCard
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopySSN(t *testing.T) {
+	ssn := SSN("111-11-1111")
+	in := &ssn
+
+	out := new(SSN)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *SSN
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyHexColor(t *testing.T) {
+	hexColor := HexColor("#FFFFFF")
+	in := &hexColor
+
+	out := new(HexColor)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *HexColor
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyRGBColor(t *testing.T) {
+	rgbColor := RGBColor("rgb(255,255,255)")
+	in := &rgbColor
+
+	out := new(RGBColor)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *RGBColor
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}
+
+func TestDeepCopyPassword(t *testing.T) {
+	password := Password("super secret stuff here")
+	in := &password
+
+	out := new(Password)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *Password
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}

--- a/duration.go
+++ b/duration.go
@@ -201,3 +201,19 @@ func (d *Duration) SetBSON(raw bson.Raw) error {
 
 	return errors.New("couldn't unmarshal bson raw value as Duration")
 }
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *Duration) DeepCopyInto(out *Duration) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new Duration.
+func (in *Duration) DeepCopy() *Duration {
+	if in == nil {
+		return nil
+	}
+	out := new(Duration)
+	in.DeepCopyInto(out)
+	return out
+}

--- a/duration_test.go
+++ b/duration_test.go
@@ -203,3 +203,19 @@ func TestIsDuration_Caveats(t *testing.T) {
 	assert.False(t, e)
 
 }
+
+func TestDeepCopyDuration(t *testing.T) {
+	dur := Duration(42)
+	in := &dur
+
+	out := new(Duration)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *Duration
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}

--- a/time.go
+++ b/time.go
@@ -193,3 +193,19 @@ func (t *DateTime) SetBSON(raw bson.Raw) error {
 
 	return errors.New("couldn't unmarshal bson raw value as Duration")
 }
+
+// DeepCopyInto copies the reciever and writes its value into out.
+func (in *DateTime) DeepCopyInto(out *DateTime) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver into a new DateTime.
+func (in *DateTime) DeepCopy() *DateTime {
+	if in == nil {
+		return nil
+	}
+	out := new(DateTime)
+	in.DeepCopyInto(out)
+	return out
+}

--- a/time_test.go
+++ b/time_test.go
@@ -230,3 +230,20 @@ func TestDateTime_BSON(t *testing.T) {
 		assert.Equal(t, dt, dtCopy)
 	}
 }
+
+func TestDeepCopyDateTime(t *testing.T) {
+	p, err := ParseDateTime("2011-08-18T19:03:37.000000000+01:00")
+	assert.NoError(t, err)
+	in := &p
+
+	out := new(DateTime)
+	in.DeepCopyInto(out)
+	assert.Equal(t, in, out)
+
+	out2 := in.DeepCopy()
+	assert.Equal(t, in, out2)
+
+	var inNil *DateTime
+	out3 := inNil.DeepCopy()
+	assert.Nil(t, out3)
+}


### PR DESCRIPTION
Kubernetes has a project called code-generator[0] which generates
DeepCopy methods for API models.

Cilium[1] is using code-generator on top of models generated by
go-swagger, to allow deep copying of API models. Hovewer, code-generator
assumes that every type which is not a basic type in Golang, needs to
have its own DeepCopy and DeepCopyIn methods. It includes also type
extensions which are built on top of basic types just to add methods.

Currently, if code-generator is executed on go-swagger API models which
use types from strfmt, generated DeepCopy methods fail, because strfmt
types do not implement DeepCopy.

This change adds implementations of DeepCopy and DeepCopyInto which will
allow to use go-generator together with go-swagger and strfmt.

[0] https://github.com/kubernetes/code-generator
[1] https://github.com/cilium/cilium

Signed-off-by: Michal Rostecki <mrostecki@suse.de>