### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/format.go
+++ b/format.go
@@ -225,7 +225,7 @@ func (f *defaultFormats) DelByName(name string) bool {
 	return false
 }
 
-// DelByType removes the specified format, returns true when an item was actually removed
+// DelByFormat removes the specified format, returns true when an item was actually removed
 func (f *defaultFormats) DelByFormat(strfmt Format) bool {
 	f.Lock()
 	defer f.Unlock()


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?