### PR TITLE
Use google/uuid not pborman/uuid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 - 1.11.x
 install:
 - go get -u github.com/stretchr/testify/assert
-- go get -u github.com/pborman/uuid
+- go get -u github.com/google/uuid
 - go get -u github.com/asaskevich/govalidator
 - go get -u github.com/mailru/easyjson
 - go get -u github.com/go-openapi/errors

--- a/default_test.go
+++ b/default_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/globalsign/mgo/bson"
-	"github.com/pborman/uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -171,8 +171,8 @@ func TestFormatMAC(t *testing.T) {
 }
 
 func TestFormatUUID3(t *testing.T) {
-	first3 := uuid.NewMD5(uuid.NameSpace_URL, []byte("somewhere.com"))
-	other3 := uuid.NewMD5(uuid.NameSpace_URL, []byte("somewhereelse.com"))
+	first3 := uuid.NewMD5(uuid.NameSpaceURL, []byte("somewhere.com"))
+	other3 := uuid.NewMD5(uuid.NameSpaceURL, []byte("somewhereelse.com"))
 	uuid3 := UUID3(first3.String())
 	str := other3.String()
 	testStringFormat(t, &uuid3, "uuid3", str, []string{}, []string{"not-a-uuid"})
@@ -185,8 +185,8 @@ func TestFormatUUID3(t *testing.T) {
 }
 
 func TestFormatUUID4(t *testing.T) {
-	first4 := uuid.NewRandom()
-	other4 := uuid.NewRandom()
+	first4 := uuid.Must(uuid.NewRandom())
+	other4 := uuid.Must(uuid.NewRandom())
 	uuid4 := UUID4(first4.String())
 	str := other4.String()
 	testStringFormat(t, &uuid4, "uuid4", str, []string{}, []string{"not-a-uuid"})
@@ -199,8 +199,8 @@ func TestFormatUUID4(t *testing.T) {
 }
 
 func TestFormatUUID5(t *testing.T) {
-	first5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhere.com"))
-	other5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhereelse.com"))
+	first5 := uuid.NewSHA1(uuid.NameSpaceURL, []byte("somewhere.com"))
+	other5 := uuid.NewSHA1(uuid.NameSpaceURL, []byte("somewhereelse.com"))
 	uuid5 := UUID5(first5.String())
 	str := other5.String()
 	testStringFormat(t, &uuid5, "uuid5", str, []string{}, []string{"not-a-uuid"})
@@ -213,8 +213,8 @@ func TestFormatUUID5(t *testing.T) {
 }
 
 func TestFormatUUID(t *testing.T) {
-	first5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhere.com"))
-	other5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhereelse.com"))
+	first5 := uuid.NewSHA1(uuid.NameSpaceURL, []byte("somewhere.com"))
+	other5 := uuid.NewSHA1(uuid.NameSpaceURL, []byte("somewhereelse.com"))
 	uuid := UUID(first5.String())
 	str := other5.String()
 	testStringFormat(t, &uuid, "uuid", str, []string{}, []string{"not-a-uuid"})
@@ -570,7 +570,7 @@ func TestDeepCopyMAC(t *testing.T) {
 }
 
 func TestDeepCopyUUID(t *testing.T) {
-	first5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhere.com"))
+	first5 := uuid.NewSHA1(uuid.NameSpaceURL, []byte("somewhere.com"))
 	uuid := UUID(first5.String())
 	in := &uuid
 
@@ -587,7 +587,7 @@ func TestDeepCopyUUID(t *testing.T) {
 }
 
 func TestDeepCopyUUID3(t *testing.T) {
-	first3 := uuid.NewMD5(uuid.NameSpace_URL, []byte("somewhere.com"))
+	first3 := uuid.NewMD5(uuid.NameSpaceURL, []byte("somewhere.com"))
 	uuid3 := UUID3(first3.String())
 	in := &uuid3
 
@@ -604,7 +604,7 @@ func TestDeepCopyUUID3(t *testing.T) {
 }
 
 func TestDeepCopyUUID4(t *testing.T) {
-	first4 := uuid.NewRandom()
+	first4 := uuid.Must(uuid.NewRandom())
 	uuid4 := UUID4(first4.String())
 	in := &uuid4
 
@@ -621,7 +621,7 @@ func TestDeepCopyUUID4(t *testing.T) {
 }
 
 func TestDeepCopyUUID5(t *testing.T) {
-	first5 := uuid.NewSHA1(uuid.NameSpace_URL, []byte("somewhere.com"))
+	first5 := uuid.NewSHA1(uuid.NameSpaceURL, []byte("somewhere.com"))
 	uuid5 := UUID5(first5.String())
 	in := &uuid5
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf
 	github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb
 	github.com/go-openapi/errors v0.17.0
+	github.com/google/uuid v1.1.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/pborman/uuid v1.2.0
 	github.com/stretchr/testify v1.2.2
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb h1:D4uzjWwKYQ5XnAvU
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-openapi/errors v0.17.0 h1:g5DzIh94VpuR/dd6Ff8KqyHNnw7yBa2xSHIPPzjRDUo=
 github.com/go-openapi/errors v0.17.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
-github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
-github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -17,8 +17,6 @@ github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
-github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=


### PR DESCRIPTION
fix #38

pborman maintains google's uuid package, and they have a complicated shared history,
but the release notes for pborman/uuid now read

The choice of this package vs the google/uuid package is largely dependent on your
use case. If you want to use UUIDs as keys, used the google/uuid version (a UUID
is an array). Use this package for compatibility, needing to distinguish between
non-set UUID and the zero UUID, prefer byte slices over arrays.

google/uuid is now a dependency of pborman/uuid which is now just a compat wrapper,
so switch to just using google/uuid. Changes are just minor API differences.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>