### PR TITLE
Issue #53: Added support for parsing ISO8601 timestamps that are in local time.

### DIFF
--- a/time.go
+++ b/time.go
@@ -56,12 +56,14 @@ const (
 	RFC3339Millis = "2006-01-02T15:04:05.000Z07:00"
 	// RFC3339Micro represents a ISO8601 format to micro instead of to nano
 	RFC3339Micro = "2006-01-02T15:04:05.000000Z07:00"
+	// ISO8601LocalTime represents a ISO8601 format to ISO8601 in local time (no timezone)
+	ISO8601LocalTime = "2006-01-02T15:04:05"
 	// DateTimePattern pattern to match for the date-time format from http://tools.ietf.org/html/rfc3339#section-5.6
 	DateTimePattern = `^([0-9]{2}):([0-9]{2}):([0-9]{2})(.[0-9]+)?(z|([+-][0-9]{2}:[0-9]{2}))$`
 )
 
 var (
-	dateTimeFormats = []string{RFC3339Micro, RFC3339Millis, time.RFC3339, time.RFC3339Nano}
+	dateTimeFormats = []string{RFC3339Micro, RFC3339Millis, time.RFC3339, time.RFC3339Nano, ISO8601LocalTime}
 	rxDateTime      = regexp.MustCompile(DateTimePattern)
 	// MarshalFormat sets the time resolution format used for marshaling time (set to milliseconds)
 	MarshalFormat = RFC3339Millis

--- a/time_test.go
+++ b/time_test.go
@@ -31,6 +31,7 @@ var (
 		time time.Time // its representation in time.Time
 		str  string    // its marshalled representation
 	}{
+		{[]byte("2014-12-15T08:00:00"), time.Date(2014, 12, 15, 8, 0, 0, 0, time.UTC), "2014-12-15T08:00:00.000Z"},
 		{[]byte("2014-12-15T08:00:00.000Z"), time.Date(2014, 12, 15, 8, 0, 0, 0, time.UTC), "2014-12-15T08:00:00.000Z"},
 		{[]byte("2011-08-18T19:03:37.000000000+01:00"), time.Date(2011, 8, 18, 19, 3, 37, 0, p.Location()), "2011-08-18T19:03:37.000+01:00"},
 		{[]byte("2014-12-15T19:30:20Z"), time.Date(2014, 12, 15, 19, 30, 20, 0, time.UTC), "2014-12-15T19:30:20.000Z"},


### PR DESCRIPTION
ISO8601 states that timestamps without their timezone component are timestamps that are in "local" time. This PR adds support for parsing those types of timestamps.