### PR TITLE
Methods for fulfil methods from encoding and gob packages

### DIFF
--- a/date.go
+++ b/date.go
@@ -170,11 +170,13 @@ func (d Date) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
 func (d *Date) UnmarshalBinary(data []byte) error {
 	var original time.Time
+
 	err := original.UnmarshalBinary(data)
 	if err != nil {
 		return err
 	}
 
 	*d = Date(original)
+
 	return nil
 }

--- a/date.go
+++ b/date.go
@@ -151,3 +151,30 @@ func (d *Date) DeepCopy() *Date {
 	d.DeepCopyInto(out)
 	return out
 }
+
+// GobEncode implements the gob.GobEncoder interface.
+func (d Date) GobEncode() ([]byte, error) {
+	return d.MarshalBinary()
+}
+
+// GobDecode implements the gob.GobDecoder interface.
+func (d *Date) GobDecode(data []byte) error {
+	return d.UnmarshalBinary(data)
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (d Date) MarshalBinary() ([]byte, error) {
+	return time.Time(d).MarshalBinary()
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+func (d *Date) UnmarshalBinary(data []byte) error {
+	var original time.Time
+	err := original.UnmarshalBinary(data)
+	if err != nil {
+		return err
+	}
+
+	*d = Date(original)
+	return nil
+}

--- a/date_test.go
+++ b/date_test.go
@@ -152,8 +152,11 @@ func TestGobEncodingDate(t *testing.T) {
 	assert.NotEmpty(t, b.Bytes())
 
 	var result Date
+
 	dec := gob.NewDecoder(&b)
 	err = dec.Decode(&result)
 	assert.NoError(t, err)
-	assert.Equal(t, Date(now).String(), result.String())
+	assert.Equal(t, now.Year(), time.Time(result).Year())
+	assert.Equal(t, now.Month(), time.Time(result).Month())
+	assert.Equal(t, now.Day(), time.Time(result).Day())
 }

--- a/date_test.go
+++ b/date_test.go
@@ -15,8 +15,10 @@
 package strfmt
 
 import (
+	"bytes"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/gob"
 	"testing"
 	"time"
 
@@ -138,4 +140,20 @@ func TestDeepCopyDate(t *testing.T) {
 	var inNil *Date
 	out3 := inNil.DeepCopy()
 	assert.Nil(t, out3)
+}
+
+func TestGobEncodingDate(t *testing.T) {
+	now := time.Now()
+
+	b := bytes.Buffer{}
+	enc := gob.NewEncoder(&b)
+	err := enc.Encode(Date(now))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, b.Bytes())
+
+	var result Date
+	dec := gob.NewDecoder(&b)
+	err = dec.Decode(&result)
+	assert.NoError(t, err)
+	assert.Equal(t, Date(now).String(), result.String())
 }

--- a/time.go
+++ b/time.go
@@ -201,3 +201,30 @@ func (t *DateTime) DeepCopy() *DateTime {
 	t.DeepCopyInto(out)
 	return out
 }
+
+// GobEncode implements the gob.GobEncoder interface.
+func (t DateTime) GobEncode() ([]byte, error) {
+	return t.MarshalBinary()
+}
+
+// GobDecode implements the gob.GobDecoder interface.
+func (t *DateTime) GobDecode(data []byte) error {
+	return t.UnmarshalBinary(data)
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (t DateTime) MarshalBinary() ([]byte, error) {
+	return time.Time(t).MarshalBinary()
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+func (t *DateTime) UnmarshalBinary(data []byte) error {
+	var original time.Time
+	err := original.UnmarshalBinary(data)
+	if err != nil {
+		return err
+	}
+
+	*t = DateTime(original)
+	return nil
+}

--- a/time.go
+++ b/time.go
@@ -220,11 +220,13 @@ func (t DateTime) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
 func (t *DateTime) UnmarshalBinary(data []byte) error {
 	var original time.Time
+
 	err := original.UnmarshalBinary(data)
 	if err != nil {
 		return err
 	}
 
 	*t = DateTime(original)
+
 	return nil
 }

--- a/time_test.go
+++ b/time_test.go
@@ -16,6 +16,7 @@ package strfmt
 
 import (
 	"bytes"
+	"encoding/gob"
 	"testing"
 	"time"
 
@@ -251,4 +252,20 @@ func TestDeepCopyDateTime(t *testing.T) {
 	var inNil *DateTime
 	out3 := inNil.DeepCopy()
 	assert.Nil(t, out3)
+}
+
+func TestGobEncodingDateTime(t *testing.T) {
+	now := time.Now()
+
+	b := bytes.Buffer{}
+	enc := gob.NewEncoder(&b)
+	err := enc.Encode(DateTime(now))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, b.Bytes())
+
+	var result DateTime
+	dec := gob.NewDecoder(&b)
+	err = dec.Decode(&result)
+	assert.NoError(t, err)
+	assert.Equal(t, DateTime(now).String(), result.String())
 }

--- a/time_test.go
+++ b/time_test.go
@@ -264,8 +264,14 @@ func TestGobEncodingDateTime(t *testing.T) {
 	assert.NotEmpty(t, b.Bytes())
 
 	var result DateTime
+
 	dec := gob.NewDecoder(&b)
 	err = dec.Decode(&result)
 	assert.NoError(t, err)
-	assert.Equal(t, DateTime(now).String(), result.String())
+	assert.Equal(t, now.Year(), time.Time(result).Year())
+	assert.Equal(t, now.Month(), time.Time(result).Month())
+	assert.Equal(t, now.Day(), time.Time(result).Day())
+	assert.Equal(t, now.Hour(), time.Time(result).Hour())
+	assert.Equal(t, now.Minute(), time.Time(result).Minute())
+	assert.Equal(t, now.Second(), time.Time(result).Second())
 }


### PR DESCRIPTION
Add methods for Date and DateTime to fulfil interfaces:
- gob.GobEncoder
- gob.GobDecoder
- encoding.BinaryMarshaler
- encoding.BinaryUnmarshaler

During struct serialisation, by using core package "encoding/gob", in case Date or DateTime are used as types for struct fields, error is thrown as result: "type strfmt.Date has no exported fields".

This commits adds those method, by reusing existing ones from time.Time struct.