### PR TITLE
Added support for Linux on Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ after_success:
 go:
 - 1.13.x
 - 1.14.x
+arch:
+  - amd64
+  - ppc64le
 install:
 - GO111MODULE=off go get -u gotest.tools/gotestsum
 language: go


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/strfmt/builds/191869790
Please have a look.

Regards,
ujjwal