### PR TITLE
Export DateTimeFormats variable used by ParseDateTime()

### DIFF
--- a/time.go
+++ b/time.go
@@ -55,25 +55,26 @@ func IsDateTime(str string) bool {
 const (
 	// RFC3339Millis represents a ISO8601 format to millis instead of to nanos
 	RFC3339Millis = "2006-01-02T15:04:05.000Z07:00"
-	// RFC3339Millis represents a ISO8601 format to millis instead of to nanos
+	// RFC3339MillisNoColon represents a ISO8601 format to millis instead of to nanos
 	RFC3339MillisNoColon = "2006-01-02T15:04:05.000Z0700"
 	// RFC3339Micro represents a ISO8601 format to micro instead of to nano
 	RFC3339Micro = "2006-01-02T15:04:05.000000Z07:00"
-	// RFC3339Micro represents a ISO8601 format to micro instead of to nano
+	// RFC3339MicroNoColon represents a ISO8601 format to micro instead of to nano
 	RFC3339MicroNoColon = "2006-01-02T15:04:05.000000Z0700"
 	// ISO8601LocalTime represents a ISO8601 format to ISO8601 in local time (no timezone)
 	ISO8601LocalTime = "2006-01-02T15:04:05"
 	// ISO8601TimeWithReducedPrecision represents a ISO8601 format with reduced precision (dropped secs)
 	ISO8601TimeWithReducedPrecision = "2006-01-02T15:04Z"
-	// ISO8601TimeWithReducedPrecision represents a ISO8601 format with reduced precision and no timezone (dropped seconds + no timezone)
+	// ISO8601TimeWithReducedPrecisionLocaltime represents a ISO8601 format with reduced precision and no timezone (dropped seconds + no timezone)
 	ISO8601TimeWithReducedPrecisionLocaltime = "2006-01-02T15:04"
 	// DateTimePattern pattern to match for the date-time format from http://tools.ietf.org/html/rfc3339#section-5.6
 	DateTimePattern = `^([0-9]{2}):([0-9]{2}):([0-9]{2})(.[0-9]+)?(z|([+-][0-9]{2}:[0-9]{2}))$`
 )
 
 var (
-	dateTimeFormats = []string{RFC3339Micro, RFC3339MicroNoColon, RFC3339Millis, RFC3339MillisNoColon, time.RFC3339, time.RFC3339Nano, ISO8601LocalTime, ISO8601TimeWithReducedPrecision, ISO8601TimeWithReducedPrecisionLocaltime}
-	rxDateTime      = regexp.MustCompile(DateTimePattern)
+	rxDateTime = regexp.MustCompile(DateTimePattern)
+	// DateTimeFormats is the collection of formats used by ParseDateTime()
+	DateTimeFormats = []string{RFC3339Micro, RFC3339MicroNoColon, RFC3339Millis, RFC3339MillisNoColon, time.RFC3339, time.RFC3339Nano, ISO8601LocalTime, ISO8601TimeWithReducedPrecision, ISO8601TimeWithReducedPrecisionLocaltime}
 	// MarshalFormat sets the time resolution format used for marshaling time (set to milliseconds)
 	MarshalFormat = RFC3339Millis
 )
@@ -84,7 +85,7 @@ func ParseDateTime(data string) (DateTime, error) {
 		return NewDateTime(), nil
 	}
 	var lastError error
-	for _, layout := range dateTimeFormats {
+	for _, layout := range DateTimeFormats {
 		dd, err := time.Parse(layout, data)
 		if err != nil {
 			lastError = err


### PR DESCRIPTION
Closes #70

This commit exports the DateTimeFormats variable so that users
can modify the set of formats used by ParseDateTime, as in this
example:
    strfmt.DateTimeFormats = append(strfmt.DateTimeFormats, "2006-01-02T15:04Z0700")

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>