### PR TITLE
ci update

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,15 @@ linters:
     - whitespace
     - wsl
     - funlen
+    - wrapcheck
+    - testpackage
+    - nlreturn
+    - gofumpt
+    - goerr113
+    - gci
+    - gomnd
+    - godot
+    - exhaustivestruct
 
 issues:
   exclude-rules:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,26 @@
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 go:
-- 1.13.x
 - 1.14.x
+- 1.x
 arch:
-  - amd64
-  - ppc64le
+- amd64
+jobs:
+  include:
+  # only run fast tests on ppc64le
+  - go: 1.x
+    arch: ppc64le
+    script:
+    - gotestsum -f short-verbose -- ./...
+
+  # include linting job, but only for latest go version and amd64 arch
+  - go: 1.x
+    arch: amd64
+    install:
+      go get github.com/golangci/golangci-lint/cmd/golangci-lint
+    script:
+    - golangci-lint run --new-from-rev master
+
 install:
 - GO111MODULE=off go get -u gotest.tools/gotestsum
 language: go

--- a/format.go
+++ b/format.go
@@ -65,7 +65,7 @@ type NameNormalizer func(string) string
 
 // DefaultNameNormalizer removes all dashes
 func DefaultNameNormalizer(name string) string {
-	return strings.Replace(name, "-", "", -1)
+	return strings.ReplaceAll(name, "-", "")
 }
 
 type defaultFormats struct {

--- a/time.go
+++ b/time.go
@@ -78,7 +78,8 @@ var (
 	// MarshalFormat sets the time resolution format used for marshaling time (set to milliseconds)
 	MarshalFormat = RFC3339Millis
 
-	// NormalizeTimeForMarshal
+	// NormalizeTimeForMarshal provides a normalization function on time befeore marshalling (e.g. time.UTC).
+	// By default, the time value is not changed.
 	NormalizeTimeForMarshal = func(t time.Time) time.Time { return t }
 )
 

--- a/time_test.go
+++ b/time_test.go
@@ -231,7 +231,7 @@ func TestDateTime_Scan_Failed(t *testing.T) {
 	err := pp.Scan(nil)
 	assert.NoError(t, err)
 	// Zero values differ...
-	//assert.Equal(t, zero, pp)
+	// assert.Equal(t, zero, pp)
 	assert.Equal(t, DateTime{}, pp)
 
 	err = pp.Scan("")


### PR DESCRIPTION
* re-enact golangci-lint linting job in CI (golangci no more operates our jobs)
* updated golangci config
* addresses a few remaining linter issues
* reduced job matrix expansion (ppc job only runs once)

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>