### PR TITLE
Add Equal methods to DateTime and Date

### DIFF
--- a/date.go
+++ b/date.go
@@ -180,3 +180,8 @@ func (d *Date) UnmarshalBinary(data []byte) error {
 
 	return nil
 }
+
+// Equal checks if two Date instances are equal
+func (d Date) Equal(d2 Date) bool {
+	return time.Time(d).Equal(time.Time(d2))
+}

--- a/date_test.go
+++ b/date_test.go
@@ -160,3 +160,15 @@ func TestGobEncodingDate(t *testing.T) {
 	assert.Equal(t, now.Month(), time.Time(result).Month())
 	assert.Equal(t, now.Day(), time.Time(result).Day())
 }
+
+func TestDate_Equal(t *testing.T) {
+	t.Parallel()
+
+	d1 := Date(time.Date(2020, 10, 11, 12, 13, 14, 15, time.UTC))
+	d2 := Date(time.Date(2020, 10, 11, 12, 13, 14, 15, time.UTC))
+	d3 := Date(time.Date(2020, 11, 12, 13, 14, 15, 16, time.UTC))
+
+	assert.True(t, d1.Equal(d1), "Same Date should Equal itself")
+	assert.True(t, d1.Equal(d2), "Date instances should be equal")
+	assert.False(t, d1.Equal(d3), "Date instances should not be equal")
+}

--- a/time.go
+++ b/time.go
@@ -274,3 +274,8 @@ func (t *DateTime) UnmarshalBinary(data []byte) error {
 
 	return nil
 }
+
+// Equal checks if two DateTime instances are equal using time.Time's Equal method
+func (t DateTime) Equal(t2 DateTime) bool {
+	return time.Time(t).Equal(time.Time(t2))
+}

--- a/time_test.go
+++ b/time_test.go
@@ -313,3 +313,13 @@ func TestGobEncodingDateTime(t *testing.T) {
 	assert.Equal(t, now.Minute(), time.Time(result).Minute())
 	assert.Equal(t, now.Second(), time.Time(result).Second())
 }
+
+func TestDateTime_Equal(t *testing.T) {
+	t.Parallel()
+
+	dt1 := DateTime(time.Now())
+	dt2 := DateTime(time.Time(dt1).Add(time.Second))
+
+	assert.True(t, dt1.Equal(dt1), "DateTime instances should be equal")
+	assert.False(t, dt1.Equal(dt2), "DateTime instances should not be equal")
+}


### PR DESCRIPTION
Adds support for for `DateTime.Equal(DateTime)` and `Date.Equal(Date)` that uses time's Equal method.

This would simplify our testing flow a lot as the dependency we use (`github.com go-test/deep`) skips checking time.Time's internal properties (exp, loc, ...) by default.
