### PR TITLE
Adds IsZero functionality to DateTime

### DIFF
--- a/time.go
+++ b/time.go
@@ -29,6 +29,12 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
 
+var (
+	// UnixZero sets the zero unix timestamp we want to compare against.
+	// Unix 0 for an EST timezone is not equivalent to a UTC timezone.
+	UnixZero = time.Unix(0, 0).UTC()
+)
+
 func init() {
 	dt := DateTime{}
 	Default.Add("datetime", &dt, IsDateTime)
@@ -126,6 +132,11 @@ func (t DateTime) String() string {
 // IsZero returns whether the date time is a zero value
 func (t DateTime) IsZero() bool {
 	return time.Time(t).IsZero()
+}
+
+// IsUnixZerom returns whether the date time is equivalent to time.Unix(0, 0).UTC().
+func (t DateTime) IsUnixZero() bool {
+	return time.Time(t) == UnixZero
 }
 
 // MarshalText implements the text marshaller interface

--- a/time.go
+++ b/time.go
@@ -123,6 +123,11 @@ func (t DateTime) String() string {
 	return NormalizeTimeForMarshal(time.Time(t)).Format(MarshalFormat)
 }
 
+// IsZero returns whether the date time is a zero value
+func (t DateTime) IsZero() bool {
+	return time.Time(t).IsZero()
+}
+
 // MarshalText implements the text marshaller interface
 func (t DateTime) MarshalText() ([]byte, error) {
 	return []byte(t.String()), nil

--- a/time_test.go
+++ b/time_test.go
@@ -63,6 +63,17 @@ func TestIsZero(t *testing.T) {
 	assert.False(t, NewDateTime().IsZero())
 }
 
+func TestIsUnixZero(t *testing.T) {
+	dt := NewDateTime()
+	assert.True(t, dt.IsUnixZero())
+	assert.NotEqual(t, dt.IsZero(), dt.IsUnixZero())
+	// Test configuring UnixZero
+	estLocation := time.FixedZone("EST", int((-5 * time.Hour).Seconds()))
+	estUnixZero := time.Unix(0, 0).In(estLocation)
+	UnixZero = estUnixZero
+	assert.True(t, DateTime(estUnixZero).IsUnixZero())
+}
+
 func TestParseDateTime_errorCases(t *testing.T) {
 	_, err := ParseDateTime("yada")
 	assert.Error(t, err)

--- a/time_test.go
+++ b/time_test.go
@@ -53,6 +53,16 @@ func TestNewDateTime(t *testing.T) {
 	assert.EqualValues(t, time.Unix(0, 0).UTC(), NewDateTime())
 }
 
+func TestIsZero(t *testing.T) {
+	var empty DateTime
+	assert.True(t, empty.IsZero())
+	assert.False(t, DateTime(time.Unix(100, 5)).IsZero())
+
+	// time.Unix(0,0) does not produce a true zero value struct,
+	// so this is expected to fail.
+	assert.False(t, NewDateTime().IsZero())
+}
+
 func TestParseDateTime_errorCases(t *testing.T) {
 	_, err := ParseDateTime("yada")
 	assert.Error(t, err)


### PR DESCRIPTION
This PR adds a new function `IsZero` to the DateTime struct. The goal of this is to satisfy a common interface, IsZeroer, used by go-yaml/yaml marshaller. `IsZero` already exists on the time.Time object, so this does not introduce any novel implementation.

For reference, here is the [documentation
note](https://pkg.go.dev/gopkg.in/yaml.v3#Marshal) on using IsZero by the `(yaml).Marshal` function. If you have a struct generated by swagger that use a proto timestamp, a strfmt.DateTime is used. When you try to marshal this to yaml, _all_ DateTime fields are skipped and excluded.