### PR TITLE
fix(uuid): UUID regexes to support all-or-none '-' separator

### DIFF
--- a/default.go
+++ b/default.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -57,24 +58,35 @@ const (
 	//   - long top-level domain names (e.g. example.london) are permitted
 	//   - symbol unicode points are permitted (e.g. emoji) (not for top-level domain)
 	HostnamePattern = `^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$`
-	// UUIDPattern Regex for UUID that allows uppercase
-	UUIDPattern = `(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$`
-	// UUID3Pattern Regex for UUID3 that allows uppercase
-	UUID3Pattern = `(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$`
-	// UUID4Pattern Regex for UUID4 that allows uppercase
-	UUID4Pattern = `(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$`
-	// UUID5Pattern Regex for UUID5 that allows uppercase
-	UUID5Pattern = `(?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$`
+
 	// json null type
 	jsonNull = "null"
 )
 
+const (
+	// UUIDPattern Regex for UUID that allows uppercase
+	//
+	// Deprecated: strfmt no longer uses regular expressions to validate UUIDs.
+	UUIDPattern = `(?i)(^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$)|(^[0-9a-f]{32}$)`
+
+	// UUID3Pattern Regex for UUID3 that allows uppercase
+	//
+	// Deprecated: strfmt no longer uses regular expressions to validate UUIDs.
+	UUID3Pattern = `(?i)(^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$)|(^[0-9a-f]{12}3[0-9a-f]{3}?[0-9a-f]{16}$)`
+
+	// UUID4Pattern Regex for UUID4 that allows uppercase
+	//
+	// Deprecated: strfmt no longer uses regular expressions to validate UUIDs.
+	UUID4Pattern = `(?i)(^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$)|(^[0-9a-f]{12}4[0-9a-f]{3}[89ab][0-9a-f]{15}$)`
+
+	// UUID5Pattern Regex for UUID5 that allows uppercase
+	//
+	// Deprecated: strfmt no longer uses regular expressions to validate UUIDs.
+	UUID5Pattern = `(?i)(^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$)|(^[0-9a-f]{12}5[0-9a-f]{3}[89ab][0-9a-f]{15}$)`
+)
+
 var (
 	rxHostname = regexp.MustCompile(HostnamePattern)
-	rxUUID     = regexp.MustCompile(UUIDPattern)
-	rxUUID3    = regexp.MustCompile(UUID3Pattern)
-	rxUUID4    = regexp.MustCompile(UUID4Pattern)
-	rxUUID5    = regexp.MustCompile(UUID5Pattern)
 )
 
 // IsHostname returns true when the string is a valid hostname
@@ -99,24 +111,28 @@ func IsHostname(str string) bool {
 	return valid
 }
 
-// IsUUID returns true is the string matches a UUID, upper case is allowed
+// IsUUID returns true is the string matches a UUID (in any version, including v6 and v7), upper case is allowed
 func IsUUID(str string) bool {
-	return rxUUID.MatchString(str)
+	_, err := uuid.Parse(str)
+	return err == nil
 }
 
-// IsUUID3 returns true is the string matches a UUID, upper case is allowed
+// IsUUID3 returns true is the string matches a UUID v3, upper case is allowed
 func IsUUID3(str string) bool {
-	return rxUUID3.MatchString(str)
+	id, err := uuid.Parse(str)
+	return err == nil && id.Version() == uuid.Version(3)
 }
 
-// IsUUID4 returns true is the string matches a UUID, upper case is allowed
+// IsUUID4 returns true is the string matches a UUID v4, upper case is allowed
 func IsUUID4(str string) bool {
-	return rxUUID4.MatchString(str)
+	id, err := uuid.Parse(str)
+	return err == nil && id.Version() == uuid.Version(4)
 }
 
-// IsUUID5 returns true is the string matches a UUID, upper case is allowed
+// IsUUID5 returns true is the string matches a UUID v5, upper case is allowed
 func IsUUID5(str string) bool {
-	return rxUUID5.MatchString(str)
+	id, err := uuid.Parse(str)
+	return err == nil && id.Version() == uuid.Version(5)
 }
 
 // IsEmail validates an email address.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-openapi/strfmt
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/go-openapi/errors v0.21.0
-	github.com/google/uuid v1.4.0
+	github.com/google/uuid v1.5.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oklog/ulid v1.3.1
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/go-openapi/errors v0.21.0/go.mod h1:jxNTMUxRCKj65yb/okJGEtahVd7uvWnuW
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
-github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=


### PR DESCRIPTION
This PR changes the UUID validation to support either
UUIDs with the expected number of separators or no separator at all.

Under the hood, UUID validation no longer relies on regular expressions
(exported regexp patterns are marked as deprecated) but on
github.com/google/uuid. This brings a significant performance
improvement on validation (~ 15-20 times faster).

Notice that some non-standard UUID schemes as well as UUID v6 and v7
now pass "IsUUID".

* contributes https://github.com/go-swagger/go-swagger/issues/2878

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>