### PR TITLE
Revert "use pointer receivers on the IsZero variants for DateTime"

### DIFF
--- a/time.go
+++ b/time.go
@@ -135,19 +135,13 @@ func (t DateTime) String() string {
 }
 
 // IsZero returns whether the date time is a zero value
-func (t *DateTime) IsZero() bool {
-	if t == nil {
-		return true
-	}
-	return time.Time(*t).IsZero()
+func (t DateTime) IsZero() bool {
+	return time.Time(t).IsZero()
 }
 
 // IsUnixZerom returns whether the date time is equivalent to time.Unix(0, 0).UTC().
-func (t *DateTime) IsUnixZero() bool {
-	if t == nil {
-		return true
-	}
-	return time.Time(*t).Equal(UnixZero)
+func (t DateTime) IsUnixZero() bool {
+	return time.Time(t) == UnixZero
 }
 
 // MarshalText implements the text marshaller interface

--- a/time_test.go
+++ b/time_test.go
@@ -58,15 +58,11 @@ func TestNewDateTime(t *testing.T) {
 func TestIsZero(t *testing.T) {
 	var empty DateTime
 	assert.True(t, empty.IsZero())
-	var nilDt *DateTime
-	assert.True(t, nilDt.IsZero())
-	small := DateTime(time.Unix(100, 5))
-	assert.False(t, small.IsZero())
+	assert.False(t, DateTime(time.Unix(100, 5)).IsZero())
 
 	// time.Unix(0,0) does not produce a true zero value struct,
 	// so this is expected to fail.
-	dt := NewDateTime()
-	assert.False(t, dt.IsZero())
+	assert.False(t, NewDateTime().IsZero())
 }
 
 func TestIsUnixZero(t *testing.T) {
@@ -77,9 +73,7 @@ func TestIsUnixZero(t *testing.T) {
 	estLocation := time.FixedZone("EST", int((-5 * time.Hour).Seconds()))
 	estUnixZero := time.Unix(0, 0).In(estLocation)
 	UnixZero = estUnixZero
-	t.Cleanup(func() { UnixZero = time.Unix(0, 0).UTC() })
-	dtz := DateTime(estUnixZero)
-	assert.True(t, dtz.IsUnixZero())
+	assert.True(t, DateTime(estUnixZero).IsUnixZero())
 }
 
 func TestParseDateTime_errorCases(t *testing.T) {


### PR DESCRIPTION
This reverts commit b36a4901fcb51dbf4300a5a6b60b4335440aa208.

Fixes https://github.com/go-openapi/strfmt/issues/139