### PR TITLE
Relint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,6 @@
 linters-settings:
-  govet:
-    check-shadowing: true
-  golint:
-    min-confidence: 0
   gocyclo:
     min-complexity: 45
-  maligned:
-    suggest-new: true
   dupl:
     threshold: 200
   goconst:
@@ -16,7 +10,7 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - maligned
+    - recvcheck
     - unparam
     - lll
     - gochecknoinits
@@ -29,9 +23,6 @@ linters:
     - wrapcheck
     - testpackage
     - nlreturn
-    - gomnd
-    - exhaustivestruct
-    - goerr113
     - errorlint
     - nestif
     - godot
@@ -39,7 +30,6 @@ linters:
     - paralleltest
     - tparallel
     - thelper
-    - ifshort
     - exhaustruct
     - varnamelen
     - gci
@@ -52,10 +42,15 @@ linters:
     - forcetypeassert
     - cyclop
     # deprecated linters
-    - deadcode
-    - interfacer
-    - scopelint
-    - varcheck
-    - structcheck
-    - golint
-    - nosnakecase
+    #- deadcode
+    #- interfacer
+    #- scopelint
+    #- varcheck
+    #- structcheck
+    #- golint
+    #- nosnakecase
+    #- maligned
+    #- goerr113
+    #- ifshort
+    #- gomnd
+    #- exhaustivestruct

--- a/bson.go
+++ b/bson.go
@@ -83,7 +83,7 @@ func (id *ObjectId) Scan(raw interface{}) error {
 	case string:
 		data = []byte(v)
 	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.URI from: %#v", v)
+		return fmt.Errorf("cannot sql.Scan() strfmt.URI from: %#v: %w", v, ErrFormat)
 	}
 
 	return id.UnmarshalText(data)

--- a/date.go
+++ b/date.go
@@ -17,7 +17,6 @@ package strfmt
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -84,7 +83,7 @@ func (d *Date) Scan(raw interface{}) error {
 		*d = Date{}
 		return nil
 	default:
-		return fmt.Errorf("cannot sql.Scan() strfmt.Date from: %#v", v)
+		return fmt.Errorf("cannot sql.Scan() strfmt.Date from: %#v: %w", v, ErrFormat)
 	}
 }
 
@@ -134,7 +133,7 @@ func (d *Date) UnmarshalBSON(data []byte) error {
 		return nil
 	}
 
-	return errors.New("couldn't unmarshal bson bytes value as Date")
+	return fmt.Errorf("couldn't unmarshal bson bytes value as Date: %w", ErrFormat)
 }
 
 // DeepCopyInto copies the receiver and writes its value into out.

--- a/default_test.go
+++ b/default_test.go
@@ -440,7 +440,7 @@ func testStringFormat(t *testing.T, what testableFormat, format, with string, va
 
 	// Stringer
 	strVal = what.String()
-	assert.Equalf(t, []byte(with), b, "[%s]String: expected %v and %v to be equal", strVal, with)
+	assert.Equalf(t, []byte(with), b, "[%s]String: expected %v and %v to be equal", format, strVal, with)
 
 	// JSON encoding interface
 	bj := []byte("\"" + with + "\"")

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,10 @@
+package strfmt
+
+type strfmtError string
+
+// ErrFormat is an error raised by the strfmt package
+const ErrFormat strfmtError = "format error"
+
+func (e strfmtError) Error() string {
+	return string(e)
+}

--- a/format.go
+++ b/format.go
@@ -16,7 +16,6 @@ package strfmt
 
 import (
 	"encoding"
-	stderrors "errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -102,7 +101,7 @@ func (f *defaultFormats) MapStructureHookFunc() mapstructure.DecodeHookFunc {
 		}
 		data, ok := obj.(string)
 		if !ok {
-			return nil, fmt.Errorf("failed to cast %+v to string", obj)
+			return nil, fmt.Errorf("failed to cast %+v to string: %w", obj, ErrFormat)
 		}
 
 		for _, v := range f.data {
@@ -118,7 +117,7 @@ func (f *defaultFormats) MapStructureHookFunc() mapstructure.DecodeHookFunc {
 				case "datetime":
 					input := data
 					if len(input) == 0 {
-						return nil, stderrors.New("empty string is an invalid datetime format")
+						return nil, fmt.Errorf("empty string is an invalid datetime format: %w", ErrFormat)
 					}
 					return ParseDateTime(input)
 				case "duration":

--- a/ulid.go
+++ b/ulid.go
@@ -4,7 +4,6 @@ import (
 	cryptorand "crypto/rand"
 	"database/sql/driver"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -98,7 +97,7 @@ func NewULID() (ULID, error) {
 	obj := ulidEntropyPool.Get()
 	entropy, ok := obj.(io.Reader)
 	if !ok {
-		return u, fmt.Errorf("failed to cast %+v to io.Reader", obj)
+		return u, fmt.Errorf("failed to cast %+v to io.Reader: %w", obj, ErrFormat)
 	}
 
 	id, err := ulid.New(ulid.Now(), entropy)
@@ -181,12 +180,12 @@ func (u *ULID) UnmarshalBSON(data []byte) error {
 	if ud, ok := m["data"].(string); ok {
 		id, err := ulid.ParseStrict(ud)
 		if err != nil {
-			return fmt.Errorf("couldn't parse bson bytes as ULID: %w", err)
+			return fmt.Errorf("couldn't parse bson bytes as ULID: %w: %w", err, ErrFormat)
 		}
 		u.ULID = id
 		return nil
 	}
-	return errors.New("couldn't unmarshal bson bytes as ULID")
+	return fmt.Errorf("couldn't unmarshal bson bytes as ULID: %w", ErrFormat)
 }
 
 // DeepCopyInto copies the receiver and writes its value into out.

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -201,9 +201,9 @@ func TestFormatULID_Scan(t *testing.T) {
 			case [16]byte:
 				return u, u.ULID.UnmarshalBinary(x[:])
 			case int: // just for linter
-				return u, fmt.Errorf("cannot sql.Scan() strfmt.ULID from: %#v", raw)
+				return u, fmt.Errorf("cannot sql.Scan() strfmt.ULID from: %#v: %w", raw, ErrFormat)
 			}
-			return u, fmt.Errorf("cannot sql.Scan() strfmt.ULID from: %#v", raw)
+			return u, fmt.Errorf("cannot sql.Scan() strfmt.ULID from: %#v: %w", raw, ErrFormat)
 		}
 
 		// get underlying binary implementation which is actually [16]byte


### PR DESCRIPTION
* updated linter config
* fixed linting issues:
  * wrapped errors
  * used explicitly named constants instead of "magic numbers"
  * used more recent stdlib API to replace bson time conversions