### PR TITLE
Enabled golang.org dep-bot auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -35,7 +35,7 @@ jobs:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Auto-merge dependabot PRs for golang.org updates
-        if: contains(steps.metadata.outputs.dependency-group, 'golang.org-dependencies')
+        if: contains(steps.metadata.outputs.dependency-names, 'golang.org')
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
golang.org updates are not auto merged. The dependency group metadata is empty.
Change to use dep name match.