### PR TITLE
fix: validate "uri" format for absolute URIs with a fragment (#131)

### DIFF
--- a/default.go
+++ b/default.go
@@ -1978,6 +1978,14 @@ func (r *Password) DeepCopy() *Password {
 }
 
 func isRequestURI(rawurl string) bool {
+	// url.ParseRequestURI assumes the input contains no "#fragment"
+	// (RFC 3986 §3.5). A URI with a fragment and an empty path, such as
+	// "https://host#@frag", is therefore misread as userinfo and rejected
+	// as "invalid userinfo". Strip the fragment first so the absolute
+	// request URI validates, matching url.Parse's RFC 3986 handling.
+	if i := strings.IndexByte(rawurl, '#'); i >= 0 {
+		rawurl = rawurl[:i]
+	}
 	_, err := url.ParseRequestURI(rawurl)
 	return err == nil
 }

--- a/default_test.go
+++ b/default_test.go
@@ -24,7 +24,11 @@ import (
 func TestFormatURI(t *testing.T) {
 	uri := URI("http://somewhere.com")
 	str := "http://somewhereelse.com"
-	testStringFormat(t, &uri, "uri", str, []string{}, []string{"somewhere.com"})
+	testStringFormat(t, &uri, "uri", str,
+		// "https://host#@frag": absolute URI with empty path and a fragment,
+		// valid per RFC 3986 (regression test for issue #131).
+		[]string{"https://portal.azure.com#@930d042f-8145-fragment"},
+		[]string{"somewhere.com"})
 }
 
 func validEmails() []string {


### PR DESCRIPTION
## Problem
Fixes #131. The `"uri"` format rejects absolute URIs that carry a fragment with an empty path, e.g. `https://portal.azure.com#@930d042f-...`, reporting them as `must be of type uri`. These are valid per RFC 3986. Confirmed on master HEAD 00af19e.

## Root cause
`isRequestURI` validates with `url.ParseRequestURI`, which is documented to assume the input carries no `#fragment` (RFC 3986 §3.5). With no path separating host and fragment, `host#@frag` is parsed as userinfo (`host#` before the `@`) and rejected as `net/url: invalid userinfo`.

## Fix
Strip the fragment before calling `url.ParseRequestURI`, matching how `url.Parse` handles RFC 3986. This preserves the existing absolute-URI check (scheme still required, relative paths still rejected) and changes only the fragment case. 8 lines in `default.go`; no API changes.

## How to test
```
$ go test -run '^TestFormatURI$' .
ok      github.com/go-openapi/strfmt    0.010s
```
On unpatched master the new sample fails:
```
--- FAIL: TestFormatURI (0.00s)
    default_test.go:27: expected "https://portal.azure.com#@930d042f-8145-fragment" of type uri to be valid
```

## Backward compatibility
No breaking changes. The fix only newly accepts URIs that are valid per RFC 3986; inputs outside the fragment-with-empty-path case keep their previous accept/reject result.

---
Assisted-by: Claude (code generation, reviewed and tested locally)
