### PR TITLE
fix: avoid panic in ParseDuration on trailing whitespace

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -144,6 +144,7 @@ func (d *Duration) UnmarshalText(data []byte) error { // validation is performed
 func ParseDuration(s string) (time.Duration, error) {
 	// NOTE: this code is largely inspired by the standard library.
 	orig := s
+	s = strings.TrimSpace(s)
 	var d uint64
 	neg := false
 

--- a/duration_test.go
+++ b/duration_test.go
@@ -162,6 +162,11 @@ func TestDurationParser(t *testing.T) {
 		"1 m45 s":              time.Minute + 45*time.Second,
 		"1m 45s":               time.Minute + 45*time.Second,
 		"1  minute 45 seconds": time.Minute + 45*time.Second,
+
+		// leading and trailing spaces
+		"  1s ": 1 * time.Second,
+		"1s   ": 1 * time.Second,
+		"   1s": 1 * time.Second,
 	}
 
 	for str, dur := range testcases {


### PR DESCRIPTION
## Change type

🔧 Bug fix

## Short description
<!-- Please provide a short description of your change -->
Trim leading and trailing whitespace from the input duration string at the start of ParseDuration. This prevents a panic in the parsing loop when strings.TrimLeftFunc(s, unicode.IsSpace) trims a string consisting entirely of trailing spaces into an empty string, which subsequently causes an index out of bounds error when checking s[0]. Added regression test cases covering leading, trailing, and combined spaces around durations (e.g., "  1s ", "1s   ", "   1s").

## Fixes
N/A

## Full description

## Checklist
* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
