### PR TITLE
fix(hostname): go1.27 idna valid label no longer tolerates trailing d…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - gomodguard_v2
     - godox
     - exhaustruct
+    - exhaustruct_v5
     - nlreturn
     - nonamedreturns
     - noinlineerr

--- a/default.go
+++ b/default.go
@@ -119,6 +119,7 @@ func IsHostname(str string) bool {
 	}
 
 	// IDNA check
+	str, _ = strings.CutSuffix(str, ".") // tolerates trailing ".", whereas IDNA ValidateLabel rule does not
 	res, err := idnaHostChecker.ToASCII(strings.ToLower(str))
 	if err != nil || res == "" {
 		return false
@@ -1976,7 +1977,7 @@ func isISBN(str string, version int) bool {
 		for i = range isbnVersion13 - 1 {
 			checksum += factor[i%2] * int32(sanitized[i]-'0')
 		}
-		return (int32(sanitized[isbnVersion13-1]-'0'))-((decimalBase-(checksum%decimalBase))%decimalBase) == 0
+		return int32(sanitized[isbnVersion13-1]-'0')-((decimalBase-(checksum%decimalBase))%decimalBase) == 0
 	default:
 		return isISBN(str, isbnVersion10) || isISBN(str, isbnVersion13)
 	}

--- a/format.go
+++ b/format.go
@@ -122,7 +122,7 @@ func (f *defaultFormats) Add(name string, strfmt Format, validator Validator) bo
 	nme := f.normalizeName(name)
 
 	tpe := reflect.TypeOf(strfmt)
-	if tpe.Kind() == reflect.Ptr {
+	if tpe.Kind() == reflect.Pointer {
 		tpe = tpe.Elem()
 	}
 
@@ -176,7 +176,7 @@ func (f *defaultFormats) DelByFormat(strfmt Format) bool {
 	defer f.Unlock()
 
 	tpe := reflect.TypeOf(strfmt)
-	if tpe.Kind() == reflect.Ptr {
+	if tpe.Kind() == reflect.Pointer {
 		tpe = tpe.Elem()
 	}
 
@@ -208,7 +208,7 @@ func (f *defaultFormats) ContainsFormat(strfmt Format) bool {
 	f.Lock()
 	defer f.Unlock()
 	tpe := reflect.TypeOf(strfmt)
-	if tpe.Kind() == reflect.Ptr {
+	if tpe.Kind() == reflect.Pointer {
 		tpe = tpe.Elem()
 	}
 


### PR DESCRIPTION
…ot in hosts

We keep our existing behavior (follows https://url.spec.whatwg.org/#concept-host-parser) and trim any trailing dot before submitting the string to idna label check.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
